### PR TITLE
予定を作成するエンドポイントの追加 #27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .tool-versions
 .env
+dump.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       sh -c "
         go mod download &&
         go install github.com/swaggo/swag/cmd/swag@latest &&
-        swag init -g cmd/api-server/main.go"
+        swag init --parseDependency --parseInternal -g cmd/api-server/main.go"
     profiles:
       - manual
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -6,7 +6,7 @@ COPY internal/go.mod internal/go.sum ./
 RUN go mod download
 COPY internal/ ./
 COPY internal/docs /app/docs
-RUN swag init -g cmd/api-server/main.go
+RUN swag init --parseDependency --parseInternal -g cmd/api-server/main.go
 RUN go build -o main ./cmd/api-server/main.go
 EXPOSE 8080
 CMD ["/app/main"]

--- a/docker/mysql/initdb/init.sql
+++ b/docker/mysql/initdb/init.sql
@@ -1,16 +1,17 @@
+-- 施設情報
 CREATE TABLE IF NOT EXISTS facilities (
     id VARCHAR(255) PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS departments (
     id VARCHAR(255) PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     facility_id VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (facility_id) REFERENCES facilities(id)
 );
 
@@ -18,24 +19,26 @@ CREATE TABLE IF NOT EXISTS teams (
     id VARCHAR(255) PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     facility_id VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (facility_id) REFERENCES facilities(id)
 );
+
+-- 権限
 
 CREATE TABLE IF NOT EXISTS policies (
     id VARCHAR(255) PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS positions (
     id VARCHAR(255) PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     facility_id VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (facility_id) REFERENCES facilities(id)
 );
 
@@ -47,6 +50,8 @@ CREATE TABLE IF NOT EXISTS position_policies (
     FOREIGN KEY (policy_id) REFERENCES policies(id)
 );
 
+-- 住所
+
 CREATE TABLE IF NOT EXISTS addresses (
     id VARCHAR(255) PRIMARY KEY,
     zip_code VARCHAR(255),
@@ -56,19 +61,18 @@ CREATE TABLE IF NOT EXISTS addresses (
     address_line2 VARCHAR(255),
     latitude DECIMAL(10, 8),
     longitude DECIMAL(11, 8),
-    created_at DATETIME,
-    updated_at DATETIME
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS areas (
     id VARCHAR(255) PRIMARY KEY,
     name VARCHAR(255),
     facility_id VARCHAR(255),
-    created_at DATETIME,
-    updated_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (facility_id) REFERENCES facilities(id)
 );
-
 
 CREATE TABLE IF NOT EXISTS area_addresses (
     address_id VARCHAR(255),
@@ -78,6 +82,7 @@ CREATE TABLE IF NOT EXISTS area_addresses (
     FOREIGN KEY (area_id) REFERENCES areas(id)
 );
 
+-- 職員
 
 CREATE TABLE IF NOT EXISTS users (
     id VARCHAR(255) PRIMARY KEY,
@@ -89,8 +94,8 @@ CREATE TABLE IF NOT EXISTS users (
     team_id VARCHAR(255) NOT NULL,
     area_id VARCHAR(255) NOT NULL,
     facility_id VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (position_id) REFERENCES positions(id),
     FOREIGN KEY (department_id) REFERENCES departments(id),
     FOREIGN KEY (team_id) REFERENCES teams(id),
@@ -106,13 +111,15 @@ CREATE TABLE IF NOT EXISTS user_policies (
     FOREIGN KEY (policy_id) REFERENCES policies(id)
 );
 
+-- 訪問情報
+
 CREATE TABLE IF NOT EXISTS service_codes (
     id VARCHAR(255) PRIMARY KEY,
     code VARCHAR(255) NOT NULL,
-    service_time_range_start int,
-    service_time_range_end int,
-    created_at DATETIME,
-    updated_at DATETIME
+    service_time_range_start INT,
+    service_time_range_end INT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS patients (
@@ -125,8 +132,8 @@ CREATE TABLE IF NOT EXISTS patients (
     area_id VARCHAR(255) NOT NULL,
     assigned_staff_id VARCHAR(255) NOT NULL,
     facility_id VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (service_code_id) REFERENCES service_codes(id),
     FOREIGN KEY (address_id) REFERENCES addresses(id),
     FOREIGN KEY (area_id) REFERENCES areas(id),
@@ -136,13 +143,20 @@ CREATE TABLE IF NOT EXISTS patients (
 
 CREATE TABLE IF NOT EXISTS routes (
     id VARCHAR(255) PRIMARY KEY,
-    travel_time int,
+    travel_time INT,
     address_id VARCHAR(255) NOT NULL,
     destination_id VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (address_id) REFERENCES addresses(id),
     FOREIGN KEY (destination_id) REFERENCES addresses(id)
+);
+
+CREATE TABLE IF NOT EXISTS visit_categories (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS visit_infos (
@@ -152,14 +166,92 @@ CREATE TABLE IF NOT EXISTS visit_infos (
     companion_id VARCHAR(255),
     route_id VARCHAR(255) NOT NULL,
     service_code_id VARCHAR(255) NOT NULL,
-    created_at DATETIME,
-    updated_at DATETIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (patient_id) REFERENCES patients(id),
     FOREIGN KEY (assigned_staff_id) REFERENCES users(id),
     FOREIGN KEY (companion_id) REFERENCES users(id),
     FOREIGN KEY (route_id) REFERENCES routes(id),
     FOREIGN KEY (service_code_id) REFERENCES service_codes(id)
 );
+
+CREATE TABLE `visit_info_visit_categories` (
+    `visit_info_id` CHAR(26) NOT NULL,
+    `visit_category_id` CHAR(26) NOT NULL,
+    PRIMARY KEY (`visit_info_id`, `visit_category_id`),
+    FOREIGN KEY (`visit_info_id`) REFERENCES `visit_infos` (`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`visit_category_id`) REFERENCES `visit_categories` (`id`) ON DELETE CASCADE
+);
+
+-- 予定関係
+CREATE TABLE IF NOT EXISTS schedule_types (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS recurring_rules (
+    id VARCHAR(255) PRIMARY KEY,
+    frequency VARCHAR(255) NOT NULL,
+    day_of_week VARCHAR(255),
+    day_of_month VARCHAR(255),
+    week_of_month VARCHAR(255),
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS schedule_cancels (
+    id VARCHAR(255) PRIMARY KEY,
+    reason VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS recurring_schedules (
+    id VARCHAR(255) PRIMARY KEY,
+    staff_id VARCHAR(255) NOT NULL,
+    schedule_type_id VARCHAR(255) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    visit_info_id VARCHAR(255),
+    title VARCHAR(255),
+    description VARCHAR(255),
+    is_over_time_work BOOLEAN NOT NULL DEFAULT FALSE,
+    recurring_exclusion_dates JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (staff_id) REFERENCES users(id),
+    FOREIGN KEY (schedule_type_id) REFERENCES schedule_types(id),
+    FOREIGN KEY (visit_info_id) REFERENCES visit_infos(id)
+);
+
+CREATE TABLE IF NOT EXISTS schedules (
+    id VARCHAR(255) PRIMARY KEY,
+    staff_id VARCHAR(255) NOT NULL,
+    schedule_type_id VARCHAR(255) NOT NULL,
+    date DATE NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    schedule_cancel_id VARCHAR(255),
+    recurring_schedule_id VARCHAR(255),
+    visit_info_id VARCHAR(255),
+    title VARCHAR(255),
+    description VARCHAR(255),
+    is_over_time_work BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (staff_id) REFERENCES users(id),
+    FOREIGN KEY (recurring_schedule_id) REFERENCES recurring_schedules(id),
+    FOREIGN KEY (schedule_type_id) REFERENCES schedule_types(id),
+    FOREIGN KEY (schedule_cancel_id) REFERENCES schedule_cancels(id),
+    FOREIGN KEY (visit_info_id) REFERENCES visit_infos(id)
+);
+
 
 
 -- Insert data
@@ -248,3 +340,20 @@ INSERT INTO service_codes (id, code, service_time_range_start, service_time_rang
 ('01JBVE7Z0K4KJ7G9C4Y8AWSVB7', '基本療養費', 30, 90, NOW(), NOW()),
 ('01JBVE7Z0K9VT9ZYJRE6YFARFX', '医', 30, 90, NOW(), NOW()),
 ('01JBVE7Z0KCS5C4ATYW3WPDHYN', '難病等複数回訪問加算(２回)', 30, 90, NOW(), NOW());
+
+-- patients
+INSERT INTO patients (id, name, preferred_time, preferred_gender, service_code_id, address_id, area_id, assigned_staff_id, facility_id, created_at, updated_at) VALUES
+('01JG8Y2DBN9X0RFG6D9WE2SNEN', '患者A', '朝', '男性', '01JBVE7Z0H0E0M6BX3FV1DK69A', '01JBBCQ314307YD69N89XT9WBN', '01JBBCQ867SR9Y001CR5HD6DNJ', '01J71685CQ0ZKYEHBRADF1Q8B4', '01J6SMYDSKKKNJCR2Y3242T7YX', NOW(), NOW()),
+('01JG8Y318VHVY1VH1H7BK7YG1C', '患者B', '昼', '女性', '01JBVE7Z0JQ9VG0E9SBSAQPYK3', '01JBBCPQ5SKAMZNDE9PY940ZZN', '01JBBCQ867SR9Y001CR5HD6DNJ', '01J71685CQ2JCBA6SAFTQ5MC87', '01J6SMYDSKKKNJCR2Y3242T7YX', NOW(), NOW()),
+('01JG8Y318VCR4ZZ0NW7SJ65F13', '患者C', '夜', '男性', '01JBVE7Z0JVGPNAZBD6QEES9XP', '01JBBCPX6RJPK18T4B7CAJG6F3', '01JBBCQP71J81VFQB2NRX77VDJ', '01J71685CQ5GXXEE7EN2ECVQR6', '01J6SMYDSKKKNJCR2Y3242T7YX', NOW(), NOW());
+
+-- visit_categories
+INSERT INTO visit_categories (id, name, created_at, updated_at) VALUES
+('01JG8Y318V1EFEGX96VC6NKMRD', '夜勤', NOW(), NOW()),
+('01JG8Y318V9KEYK76VVKHNZJCF', '緊急', NOW(), NOW()),
+('01JG8Y3QEMHHY4KR85FQJHJNQH', '入院', NOW(), NOW());
+
+-- schedule_types
+INSERT INTO schedule_types (id, name, created_at, updated_at) VALUES
+('01JG8Z3XZVD7M11CGETHQNAA6W', '訪問', NOW(), NOW()),
+('01JG8Z4740VMSJXKXPRV3NDR2R', '通常', NOW(), NOW());

--- a/docker/mysql/initdb/init.sql
+++ b/docker/mysql/initdb/init.sql
@@ -164,7 +164,7 @@ CREATE TABLE IF NOT EXISTS visit_infos (
     patient_id VARCHAR(255) NOT NULL,
     assigned_staff_id VARCHAR(255) NOT NULL,
     companion_id VARCHAR(255),
-    route_id VARCHAR(255) NOT NULL,
+    route_id VARCHAR(255),
     service_code_id VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -214,8 +214,7 @@ CREATE TABLE IF NOT EXISTS recurring_schedules (
     id VARCHAR(255) PRIMARY KEY,
     staff_id VARCHAR(255) NOT NULL,
     schedule_type_id VARCHAR(255) NOT NULL,
-    start_date DATE NOT NULL,
-    end_date DATE NOT NULL,
+    date DATE NOT NULL,
     start_time TIME NOT NULL,
     end_time TIME NOT NULL,
     visit_info_id VARCHAR(255),
@@ -223,11 +222,15 @@ CREATE TABLE IF NOT EXISTS recurring_schedules (
     description VARCHAR(255),
     is_over_time_work BOOLEAN NOT NULL DEFAULT FALSE,
     recurring_exclusion_dates JSON,
+    recurring_rule_id VARCHAR(255),
+    facility_id VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (staff_id) REFERENCES users(id),
     FOREIGN KEY (schedule_type_id) REFERENCES schedule_types(id),
-    FOREIGN KEY (visit_info_id) REFERENCES visit_infos(id)
+    FOREIGN KEY (visit_info_id) REFERENCES visit_infos(id),
+    FOREIGN KEY (recurring_rule_id) REFERENCES recurring_rules(id),
+    FOREIGN KEY (facility_id) REFERENCES facilities(id)
 );
 
 CREATE TABLE IF NOT EXISTS schedules (
@@ -243,13 +246,15 @@ CREATE TABLE IF NOT EXISTS schedules (
     title VARCHAR(255),
     description VARCHAR(255),
     is_over_time_work BOOLEAN NOT NULL DEFAULT FALSE,
+    facility_id VARCHAR(255) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (staff_id) REFERENCES users(id),
     FOREIGN KEY (recurring_schedule_id) REFERENCES recurring_schedules(id),
     FOREIGN KEY (schedule_type_id) REFERENCES schedule_types(id),
     FOREIGN KEY (schedule_cancel_id) REFERENCES schedule_cancels(id),
-    FOREIGN KEY (visit_info_id) REFERENCES visit_infos(id)
+    FOREIGN KEY (visit_info_id) REFERENCES visit_infos(id),
+    FOREIGN KEY (facility_id) REFERENCES facilities(id)
 );
 
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -77,32 +77,32 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/address.AddressDetailResponse"
+                                "$ref": "#/definitions/presentation_address.AddressDetailResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -122,31 +122,31 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/address.CreateAddressResponse"
+                            "$ref": "#/definitions/presentation_address.CreateAddressResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -177,31 +177,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/address.AddressDetailResponse"
+                            "$ref": "#/definitions/presentation_address.AddressDetailResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -232,31 +232,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/area.AreaResponse"
+                            "$ref": "#/definitions/presentation_facility_area.AreaResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -281,7 +281,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/auth.SignInRequest"
+                            "$ref": "#/definitions/presentation_auth.SignInRequest"
                         }
                     }
                 ],
@@ -289,19 +289,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/auth.SignInResponse"
+                            "$ref": "#/definitions/presentation_auth.SignInResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -326,7 +326,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/auth.SignUpRequest"
+                            "$ref": "#/definitions/presentation_auth.SignUpRequest"
                         }
                     }
                 ],
@@ -334,19 +334,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/auth.SignUpResponse"
+                            "$ref": "#/definitions/presentation_auth.SignUpResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -377,25 +377,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/department.DepartmentResponse"
+                            "$ref": "#/definitions/presentation_facility_department.DepartmentResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -426,25 +426,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/area.AreaResponse"
+                            "$ref": "#/definitions/presentation_facility_area.AreaResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -467,7 +467,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/area.CreateAreaRequest"
+                            "$ref": "#/definitions/presentation_facility_area.CreateAreaRequest"
                         }
                     }
                 ],
@@ -475,25 +475,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/area.AreaResponse"
+                            "$ref": "#/definitions/presentation_facility_area.AreaResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -524,25 +524,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/department.DepartmentResponse"
+                            "$ref": "#/definitions/presentation_facility_department.DepartmentResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -573,25 +573,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/position.PositionResponse"
+                            "$ref": "#/definitions/presentation_facility_position.PositionResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -614,7 +614,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/position.CreatePositionRequest"
+                            "$ref": "#/definitions/presentation_facility_position.CreatePositionRequest"
                         }
                     }
                 ],
@@ -622,25 +622,141 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/position.PositionResponse"
+                            "$ref": "#/definitions/presentation_facility_position.PositionResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/facilities/{facility_id}/schedules": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "予定を作成する",
+                "parameters": [
+                    {
+                        "description": "予定作成リクエスト",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.CreateScheduleRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.CreateScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/facilities/{facility_id}/schedules/recurring": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "繰り返し予定を作成する",
+                "parameters": [
+                    {
+                        "description": "予定作成リクエスト",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.CreateRecurringScheduleRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.CreateRecurringScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -672,26 +788,26 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/team.TeamResponse"
+                                "$ref": "#/definitions/presentation_facility_team.TeamResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -714,7 +830,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/team.CreateTeamRequest"
+                            "$ref": "#/definitions/presentation_facility_team.CreateTeamRequest"
                         }
                     }
                 ],
@@ -722,25 +838,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/team.TeamResponse"
+                            "$ref": "#/definitions/presentation_facility_team.TeamResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -815,20 +931,20 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/user.UserResponse"
+                                "$ref": "#/definitions/presentation_user.UserResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -850,7 +966,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/health_handler.HealthResponse"
+                            "$ref": "#/definitions/presentation_health_handler.HealthResponse"
                         }
                     }
                 }
@@ -874,26 +990,26 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/policy.PolicyResponse"
+                                "$ref": "#/definitions/presentation_policy.PolicyResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -916,7 +1032,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/policy.CreatePolicyRequest"
+                            "$ref": "#/definitions/presentation_policy.CreatePolicyRequest"
                         }
                     }
                 ],
@@ -924,19 +1040,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/policy.CreatePolicyResponse"
+                            "$ref": "#/definitions/presentation_policy.CreatePolicyResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -967,31 +1083,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/policy.PolicyResponse"
+                            "$ref": "#/definitions/presentation_policy.PolicyResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -1022,31 +1138,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/position.PositionResponse"
+                            "$ref": "#/definitions/presentation_facility_position.PositionResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -1077,31 +1193,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/team.TeamResponse"
+                            "$ref": "#/definitions/presentation_facility_team.TeamResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -1132,31 +1248,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/user.UserDetailResponse"
+                            "$ref": "#/definitions/presentation_user.UserDetailResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -1164,112 +1280,18 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "address.AddressDetailResponse": {
+        "api-buddy_domain_common.Date": {
             "type": "object",
             "properties": {
-                "addressLine1": {
-                    "type": "string"
-                },
-                "addressLine2": {
-                    "type": "string"
-                },
-                "city": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "latitude": {
-                    "type": "number"
-                },
-                "longitude": {
-                    "type": "number"
-                },
-                "prefecture": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "zipCode": {
+                "time.Time": {
                     "type": "string"
                 }
             }
         },
-        "address.CreateAddressResponse": {
+        "api-buddy_domain_policy.Policy": {
             "type": "object",
             "properties": {
-                "addressLine1": {
-                    "type": "string"
-                },
-                "addressLine2": {
-                    "type": "string"
-                },
-                "city": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "latitude": {
-                    "type": "number"
-                },
-                "longitude": {
-                    "type": "number"
-                },
-                "prefecture": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "zipCode": {
-                    "type": "string"
-                }
-            }
-        },
-        "area.AddressModel": {
-            "type": "object",
-            "properties": {
-                "address_line1": {
-                    "type": "string"
-                },
-                "address_line2": {
-                    "type": "string"
-                },
-                "city": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "latitude": {
-                    "type": "number"
-                },
-                "longitude": {
-                    "type": "number"
-                },
-                "prefecture": {
-                    "type": "string"
-                }
-            }
-        },
-        "area.AreaResponse": {
-            "type": "object",
-            "properties": {
-                "addresses": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/area.AddressModel"
-                    }
-                },
-                "facility_id": {
+                "created_at": {
                     "type": "string"
                 },
                 "id": {
@@ -1277,24 +1299,54 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },
-        "area.CreateAreaRequest": {
-            "type": "object",
-            "required": [
-                "address_ids",
-                "facility_id",
-                "name"
+        "api-buddy_domain_schedule_recurring_rule.FrequencyEnum": {
+            "type": "string",
+            "enum": [
+                "monthly",
+                "weekly"
             ],
+            "x-enum-varnames": [
+                "FrequencyMonthly",
+                "FrequencyWeekly"
+            ]
+        },
+        "api-buddy_domain_visit_info_visit_category.VisitCategoryType": {
+            "type": "string",
+            "enum": [
+                "夜勤",
+                "緊急",
+                "入院"
+            ],
+            "x-enum-varnames": [
+                "NightShift",
+                "Emergency",
+                "Hospital"
+            ]
+        },
+        "api-buddy_presentation_common.ErrorResponse": {
+            "type": "object",
             "properties": {
-                "address_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "code": {
+                    "type": "string"
                 },
-                "facility_id": {
+                "description": {
+                    "type": "string"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
+        "api-buddy_usecase_facility_position.PolicyDto": {
+            "type": "object",
+            "properties": {
+                "id": {
                     "type": "string"
                 },
                 "name": {
@@ -1302,7 +1354,77 @@ const docTemplate = `{
                 }
             }
         },
-        "auth.SignInRequest": {
+        "presentation_address.AddressDetailResponse": {
+            "type": "object",
+            "properties": {
+                "addressLine1": {
+                    "type": "string"
+                },
+                "addressLine2": {
+                    "type": "string"
+                },
+                "city": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                },
+                "prefecture": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "zipCode": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_address.CreateAddressResponse": {
+            "type": "object",
+            "properties": {
+                "addressLine1": {
+                    "type": "string"
+                },
+                "addressLine2": {
+                    "type": "string"
+                },
+                "city": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                },
+                "prefecture": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "zipCode": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_auth.SignInRequest": {
             "type": "object",
             "required": [
                 "password",
@@ -1317,7 +1439,7 @@ const docTemplate = `{
                 }
             }
         },
-        "auth.SignInResponse": {
+        "presentation_auth.SignInResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -1328,7 +1450,7 @@ const docTemplate = `{
                 }
             }
         },
-        "auth.SignUpRequest": {
+        "presentation_auth.SignUpRequest": {
             "type": "object",
             "required": [
                 "area_id",
@@ -1369,7 +1491,7 @@ const docTemplate = `{
                 }
             }
         },
-        "auth.SignUpResponse": {
+        "presentation_auth.SignUpResponse": {
             "type": "object",
             "properties": {
                 "area": {
@@ -1396,7 +1518,7 @@ const docTemplate = `{
                 "policies": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/policy.Policy"
+                        "$ref": "#/definitions/api-buddy_domain_policy.Policy"
                     }
                 },
                 "position": {
@@ -1407,21 +1529,75 @@ const docTemplate = `{
                 }
             }
         },
-        "common.ErrorResponse": {
+        "presentation_facility_area.AddressModel": {
             "type": "object",
             "properties": {
-                "code": {
+                "address_line1": {
                     "type": "string"
                 },
-                "description": {
+                "address_line2": {
                     "type": "string"
                 },
-                "msg": {
+                "city": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                },
+                "prefecture": {
                     "type": "string"
                 }
             }
         },
-        "department.DepartmentResponse": {
+        "presentation_facility_area.AreaResponse": {
+            "type": "object",
+            "properties": {
+                "addresses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/presentation_facility_area.AddressModel"
+                    }
+                },
+                "facility_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_facility_area.CreateAreaRequest": {
+            "type": "object",
+            "required": [
+                "address_ids",
+                "facility_id",
+                "name"
+            ],
+            "properties": {
+                "address_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "facility_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_facility_department.DepartmentResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -1441,71 +1617,7 @@ const docTemplate = `{
                 }
             }
         },
-        "health_handler.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "policy.CreatePolicyRequest": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "policy.CreatePolicyResponse": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "policy.Policy": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "policy.PolicyResponse": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "position.CreatePositionRequest": {
+        "presentation_facility_position.CreatePositionRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -1523,18 +1635,7 @@ const docTemplate = `{
                 }
             }
         },
-        "position.PolicyDto": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "position.PositionResponse": {
+        "presentation_facility_position.PositionResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -1552,7 +1653,7 @@ const docTemplate = `{
                 "policies": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/position.PolicyDto"
+                        "$ref": "#/definitions/api-buddy_usecase_facility_position.PolicyDto"
                     }
                 },
                 "updated_at": {
@@ -1560,7 +1661,7 @@ const docTemplate = `{
                 }
             }
         },
-        "team.CreateTeamRequest": {
+        "presentation_facility_team.CreateTeamRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1571,7 +1672,7 @@ const docTemplate = `{
                 }
             }
         },
-        "team.TeamResponse": {
+        "presentation_facility_team.TeamResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -1591,7 +1692,26 @@ const docTemplate = `{
                 }
             }
         },
-        "user.PolicyModel": {
+        "presentation_health_handler.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_policy.CreatePolicyRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_policy.CreatePolicyResponse": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1602,7 +1722,334 @@ const docTemplate = `{
                 }
             }
         },
-        "user.UserDetailResponse": {
+        "presentation_policy.PolicyResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_schedule.CreateRecurringScheduleRequest": {
+            "type": "object",
+            "required": [
+                "date",
+                "end_time",
+                "schedule_type_id",
+                "staff_id",
+                "start_time"
+            ],
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "recurring_rule": {
+                    "$ref": "#/definitions/presentation_schedule.RecurringRuleRequestModel"
+                },
+                "schedule_type_id": {
+                    "type": "string"
+                },
+                "staff_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoRequestModel"
+                }
+            }
+        },
+        "presentation_schedule.CreateRecurringScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "recurring_rule": {
+                    "$ref": "#/definitions/presentation_schedule.RecurringRuleResponseModel"
+                },
+                "schedule_type_id": {
+                    "type": "string"
+                },
+                "staff_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoResponseModel"
+                }
+            }
+        },
+        "presentation_schedule.CreateScheduleRequest": {
+            "type": "object",
+            "required": [
+                "date",
+                "end_time",
+                "schedule_type_id",
+                "staff_id",
+                "start_time"
+            ],
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "schedule_type_id": {
+                    "type": "string"
+                },
+                "staff_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoRequestModel"
+                }
+            }
+        },
+        "presentation_schedule.CreateScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "schedule_type_id": {
+                    "type": "string"
+                },
+                "staff_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoResponseModel"
+                }
+            }
+        },
+        "presentation_schedule.RecurringRuleRequestModel": {
+            "type": "object",
+            "required": [
+                "frequency",
+                "start_date"
+            ],
+            "properties": {
+                "day_of_month": {
+                    "type": "integer"
+                },
+                "days_of_week": {
+                    "type": "integer"
+                },
+                "end_date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "frequency": {
+                    "$ref": "#/definitions/api-buddy_domain_schedule_recurring_rule.FrequencyEnum"
+                },
+                "start_date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "week_of_month": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.RecurringRuleResponseModel": {
+            "type": "object",
+            "properties": {
+                "day_of_month": {
+                    "type": "integer"
+                },
+                "days_of_week": {
+                    "type": "integer"
+                },
+                "end_date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "frequency": {
+                    "$ref": "#/definitions/api-buddy_domain_schedule_recurring_rule.FrequencyEnum"
+                },
+                "start_date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "week_of_month": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.RouteRequestModel": {
+            "type": "object",
+            "required": [
+                "destination_id",
+                "from_address_id"
+            ],
+            "properties": {
+                "destination_id": {
+                    "type": "string"
+                },
+                "from_address_id": {
+                    "type": "string"
+                },
+                "travel_time": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.RouteResponseModel": {
+            "type": "object",
+            "properties": {
+                "address_id": {
+                    "type": "string"
+                },
+                "destination_id": {
+                    "type": "string"
+                },
+                "travel_time": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.VisitCategoryResponseModel": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/api-buddy_domain_visit_info_visit_category.VisitCategoryType"
+                }
+            }
+        },
+        "presentation_schedule.VisitInfoRequestModel": {
+            "type": "object",
+            "required": [
+                "assign_staff_id",
+                "patient_id",
+                "service_code_id"
+            ],
+            "properties": {
+                "assign_staff_id": {
+                    "type": "string"
+                },
+                "companion_id": {
+                    "type": "string"
+                },
+                "patient_id": {
+                    "type": "string"
+                },
+                "route": {
+                    "$ref": "#/definitions/presentation_schedule.RouteRequestModel"
+                },
+                "service_code_id": {
+                    "type": "string"
+                },
+                "visit_category_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "presentation_schedule.VisitInfoResponseModel": {
+            "type": "object",
+            "properties": {
+                "assigned_staff_id": {
+                    "type": "string"
+                },
+                "companion_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "patient_id": {
+                    "type": "string"
+                },
+                "route": {
+                    "$ref": "#/definitions/presentation_schedule.RouteResponseModel"
+                },
+                "service_code_id": {
+                    "type": "string"
+                },
+                "visit_categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/presentation_schedule.VisitCategoryResponseModel"
+                    }
+                }
+            }
+        },
+        "presentation_user.PolicyModel": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_user.UserDetailResponse": {
             "type": "object",
             "properties": {
                 "area": {
@@ -1629,7 +2076,7 @@ const docTemplate = `{
                 "policies": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/user.PolicyModel"
+                        "$ref": "#/definitions/presentation_user.PolicyModel"
                     }
                 },
                 "position": {
@@ -1646,7 +2093,7 @@ const docTemplate = `{
                 }
             }
         },
-        "user.UserResponse": {
+        "presentation_user.UserResponse": {
             "type": "object",
             "properties": {
                 "area": {

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -762,6 +762,49 @@ const docTemplate = `{
                 }
             }
         },
+        "/facilities/{facility_id}/schedules/schedule_types": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ScheduleType"
+                ],
+                "summary": "予定種別一覧を取得する",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/presentation_schedule_schedule_type.ScheduleTypeResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/facilities/{facility_id}/teams": {
             "get": {
                 "consumes": [
@@ -1277,6 +1320,92 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/visit_infos/service_codes": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ServiceCode"
+                ],
+                "summary": "サービスコード一覧を取得する",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/presentation_visit_info_service_code.ServiceCodeResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/visit_infos/visit_categories": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "VisitCategory"
+                ],
+                "summary": "訪問カテゴリ一覧を取得する",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/presentation_visit_info_visit_category.VisitCategoryResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1314,6 +1443,17 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "FrequencyMonthly",
                 "FrequencyWeekly"
+            ]
+        },
+        "api-buddy_domain_schedule_schedule_type.ScheduleTypeEnum": {
+            "type": "string",
+            "enum": [
+                "通常",
+                "訪問"
+            ],
+            "x-enum-varnames": [
+                "Normal",
+                "Visit"
             ]
         },
         "api-buddy_domain_visit_info_visit_category.VisitCategoryType": {
@@ -2038,6 +2178,17 @@ const docTemplate = `{
                 }
             }
         },
+        "presentation_schedule_schedule_type.ScheduleTypeResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/api-buddy_domain_schedule_schedule_type.ScheduleTypeEnum"
+                }
+            }
+        },
         "presentation_user.PolicyModel": {
             "type": "object",
             "properties": {
@@ -2113,6 +2264,34 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "presentation_visit_info_service_code.ServiceCodeResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "service_time_range_end": {
+                    "type": "integer"
+                },
+                "service_time_range_start": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_visit_info_visit_category.VisitCategoryResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/api-buddy_domain_visit_info_visit_category.VisitCategoryType"
                 }
             }
         }

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -756,6 +756,49 @@
                 }
             }
         },
+        "/facilities/{facility_id}/schedules/schedule_types": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ScheduleType"
+                ],
+                "summary": "予定種別一覧を取得する",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/presentation_schedule_schedule_type.ScheduleTypeResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/facilities/{facility_id}/teams": {
             "get": {
                 "consumes": [
@@ -1271,6 +1314,92 @@
                     }
                 }
             }
+        },
+        "/visit_infos/service_codes": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ServiceCode"
+                ],
+                "summary": "サービスコード一覧を取得する",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/presentation_visit_info_service_code.ServiceCodeResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/visit_infos/visit_categories": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "VisitCategory"
+                ],
+                "summary": "訪問カテゴリ一覧を取得する",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/presentation_visit_info_visit_category.VisitCategoryResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1308,6 +1437,17 @@
             "x-enum-varnames": [
                 "FrequencyMonthly",
                 "FrequencyWeekly"
+            ]
+        },
+        "api-buddy_domain_schedule_schedule_type.ScheduleTypeEnum": {
+            "type": "string",
+            "enum": [
+                "通常",
+                "訪問"
+            ],
+            "x-enum-varnames": [
+                "Normal",
+                "Visit"
             ]
         },
         "api-buddy_domain_visit_info_visit_category.VisitCategoryType": {
@@ -2032,6 +2172,17 @@
                 }
             }
         },
+        "presentation_schedule_schedule_type.ScheduleTypeResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/api-buddy_domain_schedule_schedule_type.ScheduleTypeEnum"
+                }
+            }
+        },
         "presentation_user.PolicyModel": {
             "type": "object",
             "properties": {
@@ -2107,6 +2258,34 @@
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "presentation_visit_info_service_code.ServiceCodeResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "service_time_range_end": {
+                    "type": "integer"
+                },
+                "service_time_range_start": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_visit_info_visit_category.VisitCategoryResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/api-buddy_domain_visit_info_visit_category.VisitCategoryType"
                 }
             }
         }

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -71,32 +71,32 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/address.AddressDetailResponse"
+                                "$ref": "#/definitions/presentation_address.AddressDetailResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -116,31 +116,31 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/address.CreateAddressResponse"
+                            "$ref": "#/definitions/presentation_address.CreateAddressResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -171,31 +171,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/address.AddressDetailResponse"
+                            "$ref": "#/definitions/presentation_address.AddressDetailResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -226,31 +226,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/area.AreaResponse"
+                            "$ref": "#/definitions/presentation_facility_area.AreaResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -275,7 +275,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/auth.SignInRequest"
+                            "$ref": "#/definitions/presentation_auth.SignInRequest"
                         }
                     }
                 ],
@@ -283,19 +283,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/auth.SignInResponse"
+                            "$ref": "#/definitions/presentation_auth.SignInResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/auth.SignUpRequest"
+                            "$ref": "#/definitions/presentation_auth.SignUpRequest"
                         }
                     }
                 ],
@@ -328,19 +328,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/auth.SignUpResponse"
+                            "$ref": "#/definitions/presentation_auth.SignUpResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -371,25 +371,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/department.DepartmentResponse"
+                            "$ref": "#/definitions/presentation_facility_department.DepartmentResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -420,25 +420,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/area.AreaResponse"
+                            "$ref": "#/definitions/presentation_facility_area.AreaResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -461,7 +461,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/area.CreateAreaRequest"
+                            "$ref": "#/definitions/presentation_facility_area.CreateAreaRequest"
                         }
                     }
                 ],
@@ -469,25 +469,25 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/area.AreaResponse"
+                            "$ref": "#/definitions/presentation_facility_area.AreaResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -518,25 +518,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/department.DepartmentResponse"
+                            "$ref": "#/definitions/presentation_facility_department.DepartmentResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -567,25 +567,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/position.PositionResponse"
+                            "$ref": "#/definitions/presentation_facility_position.PositionResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -608,7 +608,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/position.CreatePositionRequest"
+                            "$ref": "#/definitions/presentation_facility_position.CreatePositionRequest"
                         }
                     }
                 ],
@@ -616,25 +616,141 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/position.PositionResponse"
+                            "$ref": "#/definitions/presentation_facility_position.PositionResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/facilities/{facility_id}/schedules": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "予定を作成する",
+                "parameters": [
+                    {
+                        "description": "予定作成リクエスト",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.CreateScheduleRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.CreateScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/facilities/{facility_id}/schedules/recurring": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "繰り返し予定を作成する",
+                "parameters": [
+                    {
+                        "description": "予定作成リクエスト",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.CreateRecurringScheduleRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.CreateRecurringScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -666,26 +782,26 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/team.TeamResponse"
+                                "$ref": "#/definitions/presentation_facility_team.TeamResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -708,7 +824,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/team.CreateTeamRequest"
+                            "$ref": "#/definitions/presentation_facility_team.CreateTeamRequest"
                         }
                     }
                 ],
@@ -716,25 +832,25 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/team.TeamResponse"
+                            "$ref": "#/definitions/presentation_facility_team.TeamResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -809,20 +925,20 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/user.UserResponse"
+                                "$ref": "#/definitions/presentation_user.UserResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -844,7 +960,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/health_handler.HealthResponse"
+                            "$ref": "#/definitions/presentation_health_handler.HealthResponse"
                         }
                     }
                 }
@@ -868,26 +984,26 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/policy.PolicyResponse"
+                                "$ref": "#/definitions/presentation_policy.PolicyResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -910,7 +1026,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/policy.CreatePolicyRequest"
+                            "$ref": "#/definitions/presentation_policy.CreatePolicyRequest"
                         }
                     }
                 ],
@@ -918,19 +1034,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/policy.CreatePolicyResponse"
+                            "$ref": "#/definitions/presentation_policy.CreatePolicyResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -961,31 +1077,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/policy.PolicyResponse"
+                            "$ref": "#/definitions/presentation_policy.PolicyResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -1016,31 +1132,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/position.PositionResponse"
+                            "$ref": "#/definitions/presentation_facility_position.PositionResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -1071,31 +1187,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/team.TeamResponse"
+                            "$ref": "#/definitions/presentation_facility_team.TeamResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -1126,31 +1242,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/user.UserDetailResponse"
+                            "$ref": "#/definitions/presentation_user.UserDetailResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/common.ErrorResponse"
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
                         }
                     }
                 }
@@ -1158,112 +1274,18 @@
         }
     },
     "definitions": {
-        "address.AddressDetailResponse": {
+        "api-buddy_domain_common.Date": {
             "type": "object",
             "properties": {
-                "addressLine1": {
-                    "type": "string"
-                },
-                "addressLine2": {
-                    "type": "string"
-                },
-                "city": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "latitude": {
-                    "type": "number"
-                },
-                "longitude": {
-                    "type": "number"
-                },
-                "prefecture": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "zipCode": {
+                "time.Time": {
                     "type": "string"
                 }
             }
         },
-        "address.CreateAddressResponse": {
+        "api-buddy_domain_policy.Policy": {
             "type": "object",
             "properties": {
-                "addressLine1": {
-                    "type": "string"
-                },
-                "addressLine2": {
-                    "type": "string"
-                },
-                "city": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "latitude": {
-                    "type": "number"
-                },
-                "longitude": {
-                    "type": "number"
-                },
-                "prefecture": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "zipCode": {
-                    "type": "string"
-                }
-            }
-        },
-        "area.AddressModel": {
-            "type": "object",
-            "properties": {
-                "address_line1": {
-                    "type": "string"
-                },
-                "address_line2": {
-                    "type": "string"
-                },
-                "city": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "latitude": {
-                    "type": "number"
-                },
-                "longitude": {
-                    "type": "number"
-                },
-                "prefecture": {
-                    "type": "string"
-                }
-            }
-        },
-        "area.AreaResponse": {
-            "type": "object",
-            "properties": {
-                "addresses": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/area.AddressModel"
-                    }
-                },
-                "facility_id": {
+                "created_at": {
                     "type": "string"
                 },
                 "id": {
@@ -1271,24 +1293,54 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },
-        "area.CreateAreaRequest": {
-            "type": "object",
-            "required": [
-                "address_ids",
-                "facility_id",
-                "name"
+        "api-buddy_domain_schedule_recurring_rule.FrequencyEnum": {
+            "type": "string",
+            "enum": [
+                "monthly",
+                "weekly"
             ],
+            "x-enum-varnames": [
+                "FrequencyMonthly",
+                "FrequencyWeekly"
+            ]
+        },
+        "api-buddy_domain_visit_info_visit_category.VisitCategoryType": {
+            "type": "string",
+            "enum": [
+                "夜勤",
+                "緊急",
+                "入院"
+            ],
+            "x-enum-varnames": [
+                "NightShift",
+                "Emergency",
+                "Hospital"
+            ]
+        },
+        "api-buddy_presentation_common.ErrorResponse": {
+            "type": "object",
             "properties": {
-                "address_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "code": {
+                    "type": "string"
                 },
-                "facility_id": {
+                "description": {
+                    "type": "string"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
+        "api-buddy_usecase_facility_position.PolicyDto": {
+            "type": "object",
+            "properties": {
+                "id": {
                     "type": "string"
                 },
                 "name": {
@@ -1296,7 +1348,77 @@
                 }
             }
         },
-        "auth.SignInRequest": {
+        "presentation_address.AddressDetailResponse": {
+            "type": "object",
+            "properties": {
+                "addressLine1": {
+                    "type": "string"
+                },
+                "addressLine2": {
+                    "type": "string"
+                },
+                "city": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                },
+                "prefecture": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "zipCode": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_address.CreateAddressResponse": {
+            "type": "object",
+            "properties": {
+                "addressLine1": {
+                    "type": "string"
+                },
+                "addressLine2": {
+                    "type": "string"
+                },
+                "city": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                },
+                "prefecture": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "zipCode": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_auth.SignInRequest": {
             "type": "object",
             "required": [
                 "password",
@@ -1311,7 +1433,7 @@
                 }
             }
         },
-        "auth.SignInResponse": {
+        "presentation_auth.SignInResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -1322,7 +1444,7 @@
                 }
             }
         },
-        "auth.SignUpRequest": {
+        "presentation_auth.SignUpRequest": {
             "type": "object",
             "required": [
                 "area_id",
@@ -1363,7 +1485,7 @@
                 }
             }
         },
-        "auth.SignUpResponse": {
+        "presentation_auth.SignUpResponse": {
             "type": "object",
             "properties": {
                 "area": {
@@ -1390,7 +1512,7 @@
                 "policies": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/policy.Policy"
+                        "$ref": "#/definitions/api-buddy_domain_policy.Policy"
                     }
                 },
                 "position": {
@@ -1401,21 +1523,75 @@
                 }
             }
         },
-        "common.ErrorResponse": {
+        "presentation_facility_area.AddressModel": {
             "type": "object",
             "properties": {
-                "code": {
+                "address_line1": {
                     "type": "string"
                 },
-                "description": {
+                "address_line2": {
                     "type": "string"
                 },
-                "msg": {
+                "city": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
+                },
+                "prefecture": {
                     "type": "string"
                 }
             }
         },
-        "department.DepartmentResponse": {
+        "presentation_facility_area.AreaResponse": {
+            "type": "object",
+            "properties": {
+                "addresses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/presentation_facility_area.AddressModel"
+                    }
+                },
+                "facility_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_facility_area.CreateAreaRequest": {
+            "type": "object",
+            "required": [
+                "address_ids",
+                "facility_id",
+                "name"
+            ],
+            "properties": {
+                "address_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "facility_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_facility_department.DepartmentResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -1435,71 +1611,7 @@
                 }
             }
         },
-        "health_handler.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "policy.CreatePolicyRequest": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "policy.CreatePolicyResponse": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "policy.Policy": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "policy.PolicyResponse": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "position.CreatePositionRequest": {
+        "presentation_facility_position.CreatePositionRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -1517,18 +1629,7 @@
                 }
             }
         },
-        "position.PolicyDto": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "position.PositionResponse": {
+        "presentation_facility_position.PositionResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -1546,7 +1647,7 @@
                 "policies": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/position.PolicyDto"
+                        "$ref": "#/definitions/api-buddy_usecase_facility_position.PolicyDto"
                     }
                 },
                 "updated_at": {
@@ -1554,7 +1655,7 @@
                 }
             }
         },
-        "team.CreateTeamRequest": {
+        "presentation_facility_team.CreateTeamRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1565,7 +1666,7 @@
                 }
             }
         },
-        "team.TeamResponse": {
+        "presentation_facility_team.TeamResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -1585,7 +1686,26 @@
                 }
             }
         },
-        "user.PolicyModel": {
+        "presentation_health_handler.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_policy.CreatePolicyRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_policy.CreatePolicyResponse": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1596,7 +1716,334 @@
                 }
             }
         },
-        "user.UserDetailResponse": {
+        "presentation_policy.PolicyResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_schedule.CreateRecurringScheduleRequest": {
+            "type": "object",
+            "required": [
+                "date",
+                "end_time",
+                "schedule_type_id",
+                "staff_id",
+                "start_time"
+            ],
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "recurring_rule": {
+                    "$ref": "#/definitions/presentation_schedule.RecurringRuleRequestModel"
+                },
+                "schedule_type_id": {
+                    "type": "string"
+                },
+                "staff_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoRequestModel"
+                }
+            }
+        },
+        "presentation_schedule.CreateRecurringScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "recurring_rule": {
+                    "$ref": "#/definitions/presentation_schedule.RecurringRuleResponseModel"
+                },
+                "schedule_type_id": {
+                    "type": "string"
+                },
+                "staff_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoResponseModel"
+                }
+            }
+        },
+        "presentation_schedule.CreateScheduleRequest": {
+            "type": "object",
+            "required": [
+                "date",
+                "end_time",
+                "schedule_type_id",
+                "staff_id",
+                "start_time"
+            ],
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "schedule_type_id": {
+                    "type": "string"
+                },
+                "staff_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoRequestModel"
+                }
+            }
+        },
+        "presentation_schedule.CreateScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "schedule_type_id": {
+                    "type": "string"
+                },
+                "staff_id": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoResponseModel"
+                }
+            }
+        },
+        "presentation_schedule.RecurringRuleRequestModel": {
+            "type": "object",
+            "required": [
+                "frequency",
+                "start_date"
+            ],
+            "properties": {
+                "day_of_month": {
+                    "type": "integer"
+                },
+                "days_of_week": {
+                    "type": "integer"
+                },
+                "end_date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "frequency": {
+                    "$ref": "#/definitions/api-buddy_domain_schedule_recurring_rule.FrequencyEnum"
+                },
+                "start_date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "week_of_month": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.RecurringRuleResponseModel": {
+            "type": "object",
+            "properties": {
+                "day_of_month": {
+                    "type": "integer"
+                },
+                "days_of_week": {
+                    "type": "integer"
+                },
+                "end_date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "frequency": {
+                    "$ref": "#/definitions/api-buddy_domain_schedule_recurring_rule.FrequencyEnum"
+                },
+                "start_date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "week_of_month": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.RouteRequestModel": {
+            "type": "object",
+            "required": [
+                "destination_id",
+                "from_address_id"
+            ],
+            "properties": {
+                "destination_id": {
+                    "type": "string"
+                },
+                "from_address_id": {
+                    "type": "string"
+                },
+                "travel_time": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.RouteResponseModel": {
+            "type": "object",
+            "properties": {
+                "address_id": {
+                    "type": "string"
+                },
+                "destination_id": {
+                    "type": "string"
+                },
+                "travel_time": {
+                    "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.VisitCategoryResponseModel": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/api-buddy_domain_visit_info_visit_category.VisitCategoryType"
+                }
+            }
+        },
+        "presentation_schedule.VisitInfoRequestModel": {
+            "type": "object",
+            "required": [
+                "assign_staff_id",
+                "patient_id",
+                "service_code_id"
+            ],
+            "properties": {
+                "assign_staff_id": {
+                    "type": "string"
+                },
+                "companion_id": {
+                    "type": "string"
+                },
+                "patient_id": {
+                    "type": "string"
+                },
+                "route": {
+                    "$ref": "#/definitions/presentation_schedule.RouteRequestModel"
+                },
+                "service_code_id": {
+                    "type": "string"
+                },
+                "visit_category_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "presentation_schedule.VisitInfoResponseModel": {
+            "type": "object",
+            "properties": {
+                "assigned_staff_id": {
+                    "type": "string"
+                },
+                "companion_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "patient_id": {
+                    "type": "string"
+                },
+                "route": {
+                    "$ref": "#/definitions/presentation_schedule.RouteResponseModel"
+                },
+                "service_code_id": {
+                    "type": "string"
+                },
+                "visit_categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/presentation_schedule.VisitCategoryResponseModel"
+                    }
+                }
+            }
+        },
+        "presentation_user.PolicyModel": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "presentation_user.UserDetailResponse": {
             "type": "object",
             "properties": {
                 "area": {
@@ -1623,7 +2070,7 @@
                 "policies": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/user.PolicyModel"
+                        "$ref": "#/definitions/presentation_user.PolicyModel"
                     }
                 },
                 "position": {
@@ -1640,7 +2087,7 @@
                 }
             }
         },
-        "user.UserResponse": {
+        "presentation_user.UserResponse": {
             "type": "object",
             "properties": {
                 "area": {

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -24,6 +24,14 @@ definitions:
     x-enum-varnames:
     - FrequencyMonthly
     - FrequencyWeekly
+  api-buddy_domain_schedule_schedule_type.ScheduleTypeEnum:
+    enum:
+    - 通常
+    - 訪問
+    type: string
+    x-enum-varnames:
+    - Normal
+    - Visit
   api-buddy_domain_visit_info_visit_category.VisitCategoryType:
     enum:
     - 夜勤
@@ -505,6 +513,13 @@ definitions:
           $ref: '#/definitions/presentation_schedule.VisitCategoryResponseModel'
         type: array
     type: object
+  presentation_schedule_schedule_type.ScheduleTypeResponse:
+    properties:
+      id:
+        type: string
+      name:
+        $ref: '#/definitions/api-buddy_domain_schedule_schedule_type.ScheduleTypeEnum'
+    type: object
   presentation_user.PolicyModel:
     properties:
       id:
@@ -555,6 +570,24 @@ definitions:
         type: string
       username:
         type: string
+    type: object
+  presentation_visit_info_service_code.ServiceCodeResponse:
+    properties:
+      code:
+        type: string
+      id:
+        type: string
+      service_time_range_end:
+        type: integer
+      service_time_range_start:
+        type: integer
+    type: object
+  presentation_visit_info_visit_category.VisitCategoryResponse:
+    properties:
+      id:
+        type: string
+      name:
+        $ref: '#/definitions/api-buddy_domain_visit_info_visit_category.VisitCategoryType'
     type: object
 host: localhost:8080
 info:
@@ -1051,6 +1084,34 @@ paths:
       summary: 繰り返し予定を作成する
       tags:
       - Schedule
+  /facilities/{facility_id}/schedules/schedule_types:
+    get:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/presentation_schedule_schedule_type.ScheduleTypeResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+      summary: 予定種別一覧を取得する
+      tags:
+      - ScheduleType
   /facilities/{facility_id}/teams:
     get:
       consumes:
@@ -1388,4 +1449,60 @@ paths:
       summary: 単一のユーザーを取得する
       tags:
       - User
+  /visit_infos/service_codes:
+    get:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/presentation_visit_info_service_code.ServiceCodeResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+      summary: サービスコード一覧を取得する
+      tags:
+      - ServiceCode
+  /visit_infos/visit_categories:
+    get:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/presentation_visit_info_visit_category.VisitCategoryResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+      summary: 訪問カテゴリ一覧を取得する
+      tags:
+      - VisitCategory
 swagger: "2.0"

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -1,6 +1,56 @@
 basePath: /v1
 definitions:
-  address.AddressDetailResponse:
+  api-buddy_domain_common.Date:
+    properties:
+      time.Time:
+        type: string
+    type: object
+  api-buddy_domain_policy.Policy:
+    properties:
+      created_at:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  api-buddy_domain_schedule_recurring_rule.FrequencyEnum:
+    enum:
+    - monthly
+    - weekly
+    type: string
+    x-enum-varnames:
+    - FrequencyMonthly
+    - FrequencyWeekly
+  api-buddy_domain_visit_info_visit_category.VisitCategoryType:
+    enum:
+    - 夜勤
+    - 緊急
+    - 入院
+    type: string
+    x-enum-varnames:
+    - NightShift
+    - Emergency
+    - Hospital
+  api-buddy_presentation_common.ErrorResponse:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      msg:
+        type: string
+    type: object
+  api-buddy_usecase_facility_position.PolicyDto:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  presentation_address.AddressDetailResponse:
     properties:
       addressLine1:
         type: string
@@ -23,7 +73,7 @@ definitions:
       zipCode:
         type: string
     type: object
-  address.CreateAddressResponse:
+  presentation_address.CreateAddressResponse:
     properties:
       addressLine1:
         type: string
@@ -46,52 +96,7 @@ definitions:
       zipCode:
         type: string
     type: object
-  area.AddressModel:
-    properties:
-      address_line1:
-        type: string
-      address_line2:
-        type: string
-      city:
-        type: string
-      id:
-        type: string
-      latitude:
-        type: number
-      longitude:
-        type: number
-      prefecture:
-        type: string
-    type: object
-  area.AreaResponse:
-    properties:
-      addresses:
-        items:
-          $ref: '#/definitions/area.AddressModel'
-        type: array
-      facility_id:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  area.CreateAreaRequest:
-    properties:
-      address_ids:
-        items:
-          type: string
-        type: array
-      facility_id:
-        type: string
-      name:
-        type: string
-    required:
-    - address_ids
-    - facility_id
-    - name
-    type: object
-  auth.SignInRequest:
+  presentation_auth.SignInRequest:
     properties:
       password:
         type: string
@@ -101,14 +106,14 @@ definitions:
     - password
     - username
     type: object
-  auth.SignInResponse:
+  presentation_auth.SignInResponse:
     properties:
       access_token:
         type: string
       id_token:
         type: string
     type: object
-  auth.SignUpRequest:
+  presentation_auth.SignUpRequest:
     properties:
       area_id:
         type: string
@@ -137,7 +142,7 @@ definitions:
     - team_id
     - username
     type: object
-  auth.SignUpResponse:
+  presentation_auth.SignUpResponse:
     properties:
       area:
         type: string
@@ -155,23 +160,59 @@ definitions:
         type: string
       policies:
         items:
-          $ref: '#/definitions/policy.Policy'
+          $ref: '#/definitions/api-buddy_domain_policy.Policy'
         type: array
       position:
         type: string
       team:
         type: string
     type: object
-  common.ErrorResponse:
+  presentation_facility_area.AddressModel:
     properties:
-      code:
+      address_line1:
         type: string
-      description:
+      address_line2:
         type: string
-      msg:
+      city:
+        type: string
+      id:
+        type: string
+      latitude:
+        type: number
+      longitude:
+        type: number
+      prefecture:
         type: string
     type: object
-  department.DepartmentResponse:
+  presentation_facility_area.AreaResponse:
+    properties:
+      addresses:
+        items:
+          $ref: '#/definitions/presentation_facility_area.AddressModel'
+        type: array
+      facility_id:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  presentation_facility_area.CreateAreaRequest:
+    properties:
+      address_ids:
+        items:
+          type: string
+        type: array
+      facility_id:
+        type: string
+      name:
+        type: string
+    required:
+    - address_ids
+    - facility_id
+    - name
+    type: object
+  presentation_facility_department.DepartmentResponse:
     properties:
       created_at:
         type: string
@@ -184,48 +225,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  health_handler.HealthResponse:
-    properties:
-      status:
-        type: string
-    type: object
-  policy.CreatePolicyRequest:
-    properties:
-      name:
-        type: string
-    required:
-    - name
-    type: object
-  policy.CreatePolicyResponse:
-    properties:
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  policy.Policy:
-    properties:
-      created_at:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  policy.PolicyResponse:
-    properties:
-      created_at:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  position.CreatePositionRequest:
+  presentation_facility_position.CreatePositionRequest:
     properties:
       name:
         type: string
@@ -237,14 +237,7 @@ definitions:
     - name
     - policy_ids
     type: object
-  position.PolicyDto:
-    properties:
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  position.PositionResponse:
+  presentation_facility_position.PositionResponse:
     properties:
       created_at:
         type: string
@@ -256,19 +249,19 @@ definitions:
         type: string
       policies:
         items:
-          $ref: '#/definitions/position.PolicyDto'
+          $ref: '#/definitions/api-buddy_usecase_facility_position.PolicyDto'
         type: array
       updated_at:
         type: string
     type: object
-  team.CreateTeamRequest:
+  presentation_facility_team.CreateTeamRequest:
     properties:
       name:
         type: string
     required:
     - name
     type: object
-  team.TeamResponse:
+  presentation_facility_team.TeamResponse:
     properties:
       created_at:
         type: string
@@ -281,14 +274,245 @@ definitions:
       updated_at:
         type: string
     type: object
-  user.PolicyModel:
+  presentation_health_handler.HealthResponse:
+    properties:
+      status:
+        type: string
+    type: object
+  presentation_policy.CreatePolicyRequest:
+    properties:
+      name:
+        type: string
+    required:
+    - name
+    type: object
+  presentation_policy.CreatePolicyResponse:
     properties:
       id:
         type: string
       name:
         type: string
     type: object
-  user.UserDetailResponse:
+  presentation_policy.PolicyResponse:
+    properties:
+      created_at:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  presentation_schedule.CreateRecurringScheduleRequest:
+    properties:
+      date:
+        format: date
+        type: string
+      description:
+        type: string
+      end_time:
+        type: string
+      recurring_rule:
+        $ref: '#/definitions/presentation_schedule.RecurringRuleRequestModel'
+      schedule_type_id:
+        type: string
+      staff_id:
+        type: string
+      start_time:
+        type: string
+      title:
+        type: string
+      visit_info:
+        $ref: '#/definitions/presentation_schedule.VisitInfoRequestModel'
+    required:
+    - date
+    - end_time
+    - schedule_type_id
+    - staff_id
+    - start_time
+    type: object
+  presentation_schedule.CreateRecurringScheduleResponse:
+    properties:
+      date:
+        $ref: '#/definitions/api-buddy_domain_common.Date'
+      description:
+        type: string
+      end_time:
+        type: string
+      id:
+        type: string
+      recurring_rule:
+        $ref: '#/definitions/presentation_schedule.RecurringRuleResponseModel'
+      schedule_type_id:
+        type: string
+      staff_id:
+        type: string
+      start_time:
+        type: string
+      title:
+        type: string
+      visit_info:
+        $ref: '#/definitions/presentation_schedule.VisitInfoResponseModel'
+    type: object
+  presentation_schedule.CreateScheduleRequest:
+    properties:
+      date:
+        format: date
+        type: string
+      description:
+        type: string
+      end_time:
+        type: string
+      schedule_type_id:
+        type: string
+      staff_id:
+        type: string
+      start_time:
+        type: string
+      title:
+        type: string
+      visit_info:
+        $ref: '#/definitions/presentation_schedule.VisitInfoRequestModel'
+    required:
+    - date
+    - end_time
+    - schedule_type_id
+    - staff_id
+    - start_time
+    type: object
+  presentation_schedule.CreateScheduleResponse:
+    properties:
+      date:
+        $ref: '#/definitions/api-buddy_domain_common.Date'
+      description:
+        type: string
+      end_time:
+        type: string
+      id:
+        type: string
+      schedule_type_id:
+        type: string
+      staff_id:
+        type: string
+      start_time:
+        type: string
+      title:
+        type: string
+      visit_info:
+        $ref: '#/definitions/presentation_schedule.VisitInfoResponseModel'
+    type: object
+  presentation_schedule.RecurringRuleRequestModel:
+    properties:
+      day_of_month:
+        type: integer
+      days_of_week:
+        type: integer
+      end_date:
+        format: date
+        type: string
+      frequency:
+        $ref: '#/definitions/api-buddy_domain_schedule_recurring_rule.FrequencyEnum'
+      start_date:
+        format: date
+        type: string
+      week_of_month:
+        type: integer
+    required:
+    - frequency
+    - start_date
+    type: object
+  presentation_schedule.RecurringRuleResponseModel:
+    properties:
+      day_of_month:
+        type: integer
+      days_of_week:
+        type: integer
+      end_date:
+        $ref: '#/definitions/api-buddy_domain_common.Date'
+      frequency:
+        $ref: '#/definitions/api-buddy_domain_schedule_recurring_rule.FrequencyEnum'
+      start_date:
+        $ref: '#/definitions/api-buddy_domain_common.Date'
+      week_of_month:
+        type: integer
+    type: object
+  presentation_schedule.RouteRequestModel:
+    properties:
+      destination_id:
+        type: string
+      from_address_id:
+        type: string
+      travel_time:
+        type: integer
+    required:
+    - destination_id
+    - from_address_id
+    type: object
+  presentation_schedule.RouteResponseModel:
+    properties:
+      address_id:
+        type: string
+      destination_id:
+        type: string
+      travel_time:
+        type: integer
+    type: object
+  presentation_schedule.VisitCategoryResponseModel:
+    properties:
+      id:
+        type: string
+      name:
+        $ref: '#/definitions/api-buddy_domain_visit_info_visit_category.VisitCategoryType'
+    type: object
+  presentation_schedule.VisitInfoRequestModel:
+    properties:
+      assign_staff_id:
+        type: string
+      companion_id:
+        type: string
+      patient_id:
+        type: string
+      route:
+        $ref: '#/definitions/presentation_schedule.RouteRequestModel'
+      service_code_id:
+        type: string
+      visit_category_ids:
+        items:
+          type: string
+        type: array
+    required:
+    - assign_staff_id
+    - patient_id
+    - service_code_id
+    type: object
+  presentation_schedule.VisitInfoResponseModel:
+    properties:
+      assigned_staff_id:
+        type: string
+      companion_id:
+        type: string
+      id:
+        type: string
+      patient_id:
+        type: string
+      route:
+        $ref: '#/definitions/presentation_schedule.RouteResponseModel'
+      service_code_id:
+        type: string
+      visit_categories:
+        items:
+          $ref: '#/definitions/presentation_schedule.VisitCategoryResponseModel'
+        type: array
+    type: object
+  presentation_user.PolicyModel:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  presentation_user.UserDetailResponse:
     properties:
       area:
         type: string
@@ -306,7 +530,7 @@ definitions:
         type: string
       policies:
         items:
-          $ref: '#/definitions/user.PolicyModel'
+          $ref: '#/definitions/presentation_user.PolicyModel'
         type: array
       position:
         type: string
@@ -317,7 +541,7 @@ definitions:
       username:
         type: string
     type: object
-  user.UserResponse:
+  presentation_user.UserResponse:
     properties:
       area:
         type: string
@@ -379,24 +603,24 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/address.AddressDetailResponse'
+              $ref: '#/definitions/presentation_address.AddressDetailResponse'
             type: array
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 住所一覧を取得する
       tags:
       - Address
@@ -409,23 +633,23 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/address.CreateAddressResponse'
+            $ref: '#/definitions/presentation_address.CreateAddressResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 住所を作成する
       tags:
       - Address
@@ -445,23 +669,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/address.AddressDetailResponse'
+            $ref: '#/definitions/presentation_address.AddressDetailResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 単一の住所を取得する
       tags:
       - Address
@@ -481,23 +705,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/area.AreaResponse'
+            $ref: '#/definitions/presentation_facility_area.AreaResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 単一のエリアを取得する
       tags:
       - Area
@@ -511,22 +735,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/auth.SignInRequest'
+          $ref: '#/definitions/presentation_auth.SignInRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/auth.SignInResponse'
+            $ref: '#/definitions/presentation_auth.SignInResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: サインイン用エンドポイント
       tags:
       - Auth
@@ -540,22 +764,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/auth.SignUpRequest'
+          $ref: '#/definitions/presentation_auth.SignUpRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/auth.SignUpResponse'
+            $ref: '#/definitions/presentation_auth.SignUpResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: サインアップ用エンドポイント
       tags:
       - Auth
@@ -575,19 +799,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/department.DepartmentResponse'
+            $ref: '#/definitions/presentation_facility_department.DepartmentResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 単一の部署を取得する
       tags:
       - Department
@@ -607,19 +831,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/area.AreaResponse'
+            $ref: '#/definitions/presentation_facility_area.AreaResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 施設IDに紐づくエリアを取得する
       tags:
       - Area
@@ -632,26 +856,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/area.CreateAreaRequest'
+          $ref: '#/definitions/presentation_facility_area.CreateAreaRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/area.AreaResponse'
+            $ref: '#/definitions/presentation_facility_area.AreaResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 施設に紐づくエリアを作成する
       tags:
       - Area
@@ -671,19 +895,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/department.DepartmentResponse'
+            $ref: '#/definitions/presentation_facility_department.DepartmentResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 施設IDに紐づく部署を取得する
       tags:
       - Department
@@ -703,19 +927,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/position.PositionResponse'
+            $ref: '#/definitions/presentation_facility_position.PositionResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 施設IDに紐づく役職を取得する
       tags:
       - Position
@@ -728,29 +952,105 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/position.CreatePositionRequest'
+          $ref: '#/definitions/presentation_facility_position.CreatePositionRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/position.PositionResponse'
+            $ref: '#/definitions/presentation_facility_position.PositionResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 施設に紐づく役職を作成する
       tags:
       - Position
+  /facilities/{facility_id}/schedules:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: 予定作成リクエスト
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/presentation_schedule.CreateScheduleRequest'
+      - description: 施設ID
+        in: path
+        name: facility_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/presentation_schedule.CreateScheduleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+      summary: 予定を作成する
+      tags:
+      - Schedule
+  /facilities/{facility_id}/schedules/recurring:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: 予定作成リクエスト
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/presentation_schedule.CreateRecurringScheduleRequest'
+      - description: 施設ID
+        in: path
+        name: facility_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/presentation_schedule.CreateRecurringScheduleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+      summary: 繰り返し予定を作成する
+      tags:
+      - Schedule
   /facilities/{facility_id}/teams:
     get:
       consumes:
@@ -767,20 +1067,20 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/team.TeamResponse'
+              $ref: '#/definitions/presentation_facility_team.TeamResponse'
             type: array
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 施設IDに紐づくチームを取得する
       tags:
       - Team
@@ -793,26 +1093,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/team.CreateTeamRequest'
+          $ref: '#/definitions/presentation_facility_team.CreateTeamRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/team.TeamResponse'
+            $ref: '#/definitions/presentation_facility_team.TeamResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 施設に紐づくチームを作成する
       tags:
       - Team
@@ -861,16 +1161,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/user.UserResponse'
+              $ref: '#/definitions/presentation_user.UserResponse'
             type: array
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 施設IDに紐づくユーザーを取得する
       tags:
       - User
@@ -884,7 +1184,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/health_handler.HealthResponse'
+            $ref: '#/definitions/presentation_health_handler.HealthResponse'
       summary: ヘルスチェック用エンドポイント
       tags:
       - Health
@@ -899,20 +1199,20 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/policy.PolicyResponse'
+              $ref: '#/definitions/presentation_policy.PolicyResponse'
             type: array
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: ポリシー一覧を取得する
       tags:
       - Policy
@@ -925,22 +1225,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/policy.CreatePolicyRequest'
+          $ref: '#/definitions/presentation_policy.CreatePolicyRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/policy.CreatePolicyResponse'
+            $ref: '#/definitions/presentation_policy.CreatePolicyResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: ポリシーを作成する
       tags:
       - Policy
@@ -960,23 +1260,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/policy.PolicyResponse'
+            $ref: '#/definitions/presentation_policy.PolicyResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 単一のポリシーを取得する
       tags:
       - Policy
@@ -996,23 +1296,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/position.PositionResponse'
+            $ref: '#/definitions/presentation_facility_position.PositionResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 単一の役職を取得する
       tags:
       - Position
@@ -1032,23 +1332,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/team.TeamResponse'
+            $ref: '#/definitions/presentation_facility_team.TeamResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 単一のチーム取得する
       tags:
       - Team
@@ -1068,23 +1368,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/user.UserDetailResponse'
+            $ref: '#/definitions/presentation_user.UserDetailResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/common.ErrorResponse'
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
       summary: 単一のユーザーを取得する
       tags:
       - User

--- a/internal/domain/common/date_time.go
+++ b/internal/domain/common/date_time.go
@@ -1,0 +1,110 @@
+package common
+
+import (
+	"database/sql/driver"
+	"time"
+
+	errorDomain "api-buddy/domain/error"
+	"encoding/json"
+)
+
+// 日付 (yyyy/mm/dd) のカスタム型
+type Date struct {
+	time.Time
+}
+
+func (d Date) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Format("2006-01-02"))
+}
+
+// Date型のカスタムフォーマット
+func (d *Date) UnmarshalJSON(data []byte) error {
+	var dateStr string
+	if err := json.Unmarshal(data, &dateStr); err != nil {
+		return err
+	}
+	parsed, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return err
+	}
+	d.Time = parsed
+	return nil
+}
+
+// Date型: データベースへの保存
+func (d Date) Value() (driver.Value, error) {
+	return d.Format("2006-01-02"), nil
+}
+
+// Date型: データベースからの読み取り
+func (d *Date) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case time.Time:
+		d.Time = v
+		return nil
+	case string:
+		parsed, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			return err
+		}
+		d.Time = parsed
+		return nil
+	default:
+		return errorDomain.NewError("Date型に変換できません")
+	}
+}
+
+// 時刻 (hh:mm) のカスタム型
+type Time struct {
+	time.Time
+}
+
+// Time型: JSONへの出力
+func (t Time) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Format("15:04")) // hh:mm形式
+}
+
+// Time型: JSONからの入力
+func (t *Time) UnmarshalJSON(data []byte) error {
+	var timeStr string
+	if err := json.Unmarshal(data, &timeStr); err != nil {
+		return err
+	}
+	parsed, err := time.Parse("15:04", timeStr)
+	if err != nil {
+		return err
+	}
+	t.Time = parsed
+	return nil
+}
+
+// Time型: データベースへの保存
+func (t Time) Value() (driver.Value, error) {
+	return t.Format("15:04:05"), nil
+}
+
+// Time型: データベースからの読み取り
+func (t *Time) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case time.Time:
+		t.Time = v
+		return nil
+	case string:
+		parsed, err := time.Parse("15:04:05", v)
+		if err != nil {
+			return err
+		}
+		t.Time = parsed
+		return nil
+	case []uint8:
+		strValue := string(v)
+		parsed, err := time.Parse("15:04:05", strValue)
+		if err != nil {
+			return err
+		}
+		t.Time = parsed
+		return nil
+	default:
+		return errorDomain.NewError("Time型に変換できません")
+	}
+}

--- a/internal/domain/common/json.go
+++ b/internal/domain/common/json.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	errorDomain "api-buddy/domain/error"
+	"database/sql/driver"
+	"encoding/json"
+)
+
+type JSONSlice[T any] []T
+
+func (j *JSONSlice[T]) Scan(value interface{}) error {
+	if value == nil {
+		*j = nil
+		return nil
+	}
+
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errorDomain.NewError("type assertion to []byte failed")
+	}
+
+	return json.Unmarshal(bytes, j)
+}
+
+// Value implements the driver.Valuer interface
+func (j JSONSlice[T]) Value() (driver.Value, error) {
+	if len(j) == 0 {
+		return "[]", nil
+	}
+	return json.Marshal(j)
+}

--- a/internal/domain/patient/patient.go
+++ b/internal/domain/patient/patient.go
@@ -12,20 +12,20 @@ import (
 )
 
 type Patient struct {
-	ID               string
-	Name             string
-	PreferredTime    string
-	PreferredGender  string
-	ServiceCodeID    string
-	ServiceCode      *serviceCodeDomain.ServiceCode `gorm:"foreignKey:ServiceCodeID"`
-	AddressID        string
-	Address          *addressDomain.Address `gorm:"foreignKey:AddressID"`
-	AreaID           string
-	Area             *areaDomain.Area `gorm:"foreignKey:AreaID"`
-	Assigned_StaffID string
-	Assigned_Staff   *userDomain.User `gorm:"foreignKey:Assigned_StaffID"`
-	FacilityID       string
-	Facility         *facilityDomain.Facility `gorm:"foreignKey:FacilityID"`
+	ID              string
+	Name            string
+	PreferredTime   string
+	PreferredGender string
+	ServiceCodeID   string
+	ServiceCode     *serviceCodeDomain.ServiceCode `gorm:"foreignKey:ServiceCodeID"`
+	AddressID       string
+	Address         *addressDomain.Address `gorm:"foreignKey:AddressID"`
+	AreaID          string
+	Area            *areaDomain.Area `gorm:"foreignKey:AreaID"`
+	AssignedStaffID string
+	AssignedStaff   *userDomain.User `gorm:"foreignKey:AssignedStaffID"`
+	FacilityID      string
+	Facility        *facilityDomain.Facility `gorm:"foreignKey:FacilityID"`
 	common.CommonModel
 }
 

--- a/internal/domain/schedule/recurring_rule/recurring_rule.go
+++ b/internal/domain/schedule/recurring_rule/recurring_rule.go
@@ -1,0 +1,57 @@
+package recurring_rule
+
+import (
+	"api-buddy/domain/common"
+	"time"
+
+	"github.com/Fukuemon/go-pkg/ulid"
+)
+
+type RecurringRule struct {
+	ID          string `grom:"primaryKey"`
+	Frequency   string
+	DaysOfWeek  int
+	DayOfMonth  int
+	WeekOfMonth int
+	StartDate   time.Time
+	EndDate     time.Time
+	common.CommonModel
+}
+
+func NewRecurringRule(
+	frequency string,
+	daysOfWeek int,
+	dayOfMonth int,
+	weekOfMonth int,
+	startDate time.Time,
+	endDate time.Time,
+) (*RecurringRule, error) {
+	return newRecurringRule(
+		ulid.NewULID(),
+		frequency, daysOfWeek,
+		dayOfMonth, weekOfMonth,
+		startDate,
+		endDate,
+	)
+}
+
+func newRecurringRule(
+	id string,
+	frequency string,
+	daysOfWeek int,
+	dayOfMonth int,
+	weekOfMonth int,
+	startDate time.Time, endDate time.Time) (*RecurringRule, error) {
+	recurring_rule := &RecurringRule{
+		ID:          id,
+		Frequency:   frequency,
+		DaysOfWeek:  daysOfWeek,
+		DayOfMonth:  dayOfMonth,
+		WeekOfMonth: weekOfMonth,
+		StartDate:   startDate,
+		EndDate:     endDate,
+	}
+
+	common.InitializeCommonModel(&recurring_rule.CommonModel)
+	return recurring_rule, nil
+}

--- a/internal/domain/schedule/recurring_rule/recurring_rule.go
+++ b/internal/domain/schedule/recurring_rule/recurring_rule.go
@@ -18,7 +18,7 @@ const (
 type RecurringRule struct {
 	ID          string `grom:"primaryKey"`
 	Frequency   FrequencyEnum
-	DaysOfWeek  int
+	DayOfWeek   int
 	DayOfMonth  int
 	WeekOfMonth int
 	StartDate   common.Date
@@ -28,9 +28,9 @@ type RecurringRule struct {
 
 type RecurringRuleOption func(*RecurringRule) error
 
-func WithDaysOfWeek(daysOfWeek int) RecurringRuleOption {
+func WithDayOfWeek(daysOfWeek int) RecurringRuleOption {
 	return func(r *RecurringRule) error {
-		r.DaysOfWeek = daysOfWeek
+		r.DayOfWeek = daysOfWeek
 		return nil
 	}
 }

--- a/internal/domain/schedule/recurring_rule/recurring_rule.go
+++ b/internal/domain/schedule/recurring_rule/recurring_rule.go
@@ -2,54 +2,94 @@ package recurring_rule
 
 import (
 	"api-buddy/domain/common"
-	"time"
+
+	errorDomain "api-buddy/domain/error"
 
 	"github.com/Fukuemon/go-pkg/ulid"
 )
 
+type FrequencyEnum string
+
+const (
+	FrequencyMonthly FrequencyEnum = "monthly"
+	FrequencyWeekly  FrequencyEnum = "weekly"
+)
+
 type RecurringRule struct {
 	ID          string `grom:"primaryKey"`
-	Frequency   string
+	Frequency   FrequencyEnum
 	DaysOfWeek  int
 	DayOfMonth  int
 	WeekOfMonth int
-	StartDate   time.Time
-	EndDate     time.Time
+	StartDate   common.Date
+	EndDate     common.Date
 	common.CommonModel
 }
 
+type RecurringRuleOption func(*RecurringRule) error
+
+func WithDaysOfWeek(daysOfWeek int) RecurringRuleOption {
+	return func(r *RecurringRule) error {
+		r.DaysOfWeek = daysOfWeek
+		return nil
+	}
+}
+
+func WithDayOfMonth(dayOfMonth int) RecurringRuleOption {
+	return func(r *RecurringRule) error {
+		r.DayOfMonth = dayOfMonth
+		return nil
+	}
+}
+
+func WithWeekOfMonth(weekOfMonth int) RecurringRuleOption {
+	return func(r *RecurringRule) error {
+		r.WeekOfMonth = weekOfMonth
+		return nil
+	}
+}
+
+func WithEndDate(endDate common.Date) RecurringRuleOption {
+	return func(r *RecurringRule) error {
+		r.EndDate = endDate
+		return nil
+	}
+}
+
 func NewRecurringRule(
-	frequency string,
-	daysOfWeek int,
-	dayOfMonth int,
-	weekOfMonth int,
-	startDate time.Time,
-	endDate time.Time,
+	frequency FrequencyEnum,
+	startDate common.Date,
+	options ...RecurringRuleOption,
 ) (*RecurringRule, error) {
 	return newRecurringRule(
 		ulid.NewULID(),
-		frequency, daysOfWeek,
-		dayOfMonth, weekOfMonth,
+		frequency,
 		startDate,
-		endDate,
+		options...,
 	)
 }
 
 func newRecurringRule(
 	id string,
-	frequency string,
-	daysOfWeek int,
-	dayOfMonth int,
-	weekOfMonth int,
-	startDate time.Time, endDate time.Time) (*RecurringRule, error) {
+	frequency FrequencyEnum,
+	startDate common.Date,
+	options ...RecurringRuleOption,
+) (*RecurringRule, error) {
 	recurring_rule := &RecurringRule{
-		ID:          id,
-		Frequency:   frequency,
-		DaysOfWeek:  daysOfWeek,
-		DayOfMonth:  dayOfMonth,
-		WeekOfMonth: weekOfMonth,
-		StartDate:   startDate,
-		EndDate:     endDate,
+		ID:        id,
+		Frequency: frequency,
+		StartDate: startDate,
+	}
+
+	for _, option := range options {
+		if err := option(recurring_rule); err != nil {
+			return nil, err
+		}
+	}
+	// Todo: 繰り返しルールの制約
+	//DaysOfWeek, DayOfMonth, WeekOfMonthのいずれかが設定されているか確認
+	if recurring_rule.DaysOfWeek == 0 && recurring_rule.DayOfMonth == 0 && recurring_rule.WeekOfMonth == 0 {
+		return nil, errorDomain.NewError("繰り返しルールが不正です")
 	}
 
 	common.InitializeCommonModel(&recurring_rule.CommonModel)

--- a/internal/domain/schedule/recurring_rule/recurring_rule.go
+++ b/internal/domain/schedule/recurring_rule/recurring_rule.go
@@ -87,9 +87,46 @@ func newRecurringRule(
 		}
 	}
 	// Todo: 繰り返しルールの制約
-	//DaysOfWeek, DayOfMonth, WeekOfMonthのいずれかが設定されているか確認
-	if recurring_rule.DaysOfWeek == 0 && recurring_rule.DayOfMonth == 0 && recurring_rule.WeekOfMonth == 0 {
-		return nil, errorDomain.NewError("繰り返しルールが不正です")
+	//DayOfWeek, DayOfMonth, WeekOfMonthのいずれかが設定されているか確認
+	if recurring_rule.DayOfWeek == 0 && recurring_rule.DayOfMonth == 0 && recurring_rule.WeekOfMonth == 0 {
+		err := errorDomain.NewError("繰り返しルールが不正です")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+	}
+
+	if recurring_rule.Frequency == FrequencyMonthly && recurring_rule.DayOfMonth == 0 {
+		err := errorDomain.NewError("月の日を指定してください")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+	}
+
+	if recurring_rule.Frequency == FrequencyWeekly && recurring_rule.DayOfWeek == 0 {
+		err := errorDomain.NewError("曜日を指定してください")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+	}
+
+	//DayOfWeek, DayOfMonth, WeekOfMonthのいずれかが重複していないか確認
+	if recurring_rule.DayOfWeek != 0 && recurring_rule.DayOfMonth != 0 {
+		err := errorDomain.NewError("曜日と月の日が重複しています")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+	}
+
+	if recurring_rule.WeekOfMonth != 0 && recurring_rule.DayOfMonth != 0 {
+		err := errorDomain.NewError("週の日と月の日が重複しています")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+	}
+
+	if recurring_rule.DayOfWeek != 0 && (recurring_rule.DayOfWeek < 1 || recurring_rule.DayOfWeek > 7) {
+		err := errorDomain.NewError("曜日が不正です")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+	}
+
+	if recurring_rule.DayOfMonth != 0 && (recurring_rule.DayOfMonth < 1 || recurring_rule.DayOfMonth > 31) {
+		err := errorDomain.NewError("月の日が不正です")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+	}
+
+	if recurring_rule.WeekOfMonth != 0 && (recurring_rule.WeekOfMonth < 1 || recurring_rule.WeekOfMonth > 5) {
+		err := errorDomain.NewError("週の日が不正です")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 	}
 
 	common.InitializeCommonModel(&recurring_rule.CommonModel)

--- a/internal/domain/schedule/recurring_rule/recurring_rule_repository.go
+++ b/internal/domain/schedule/recurring_rule/recurring_rule_repository.go
@@ -1,0 +1,13 @@
+package recurring_rule
+
+import (
+	"context"
+
+	"github.com/Fukuemon/go-pkg/query"
+)
+
+type RecurringRuleRepository interface {
+	FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*RecurringRule, error)
+	FindByID(ctx context.Context, id string) (*RecurringRule, error)
+	Create(ctx context.Context, recurring_rule *RecurringRule) error
+}

--- a/internal/domain/schedule/recurring_rule/recurring_rule_repository.go
+++ b/internal/domain/schedule/recurring_rule/recurring_rule_repository.go
@@ -2,12 +2,10 @@ package recurring_rule
 
 import (
 	"context"
-
-	"github.com/Fukuemon/go-pkg/query"
 )
 
 type RecurringRuleRepository interface {
-	FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*RecurringRule, error)
+	FindByFacilityID(ctx context.Context, facility_id string) ([]*RecurringRule, error)
 	FindByID(ctx context.Context, id string) (*RecurringRule, error)
 	Create(ctx context.Context, recurring_rule *RecurringRule) error
 }

--- a/internal/domain/schedule/recurring_rule/recurring_rule_repository.go
+++ b/internal/domain/schedule/recurring_rule/recurring_rule_repository.go
@@ -2,10 +2,12 @@ package recurring_rule
 
 import (
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type RecurringRuleRepository interface {
 	FindByFacilityID(ctx context.Context, facility_id string) ([]*RecurringRule, error)
 	FindByID(ctx context.Context, id string) (*RecurringRule, error)
-	Create(ctx context.Context, recurring_rule *RecurringRule) error
+	Create(ctx context.Context, tx *gorm.DB, recurring_rule *RecurringRule) error
 }

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule.go
@@ -8,6 +8,8 @@ import (
 	userDomain "api-buddy/domain/user"
 	visitInfoDomain "api-buddy/domain/visit_info"
 	"time"
+
+	"github.com/Fukuemon/go-pkg/query"
 )
 
 type Option struct {
@@ -68,7 +70,7 @@ func newRecurringSchedule(
 	if options != nil {
 		if options != nil {
 			// 通常予定の場合
-			if schedule_type.Name == scheduleTypeDomain.ScheduleTypeNormal {
+			if schedule_type.Name == scheduleTypeDomain.Normal {
 				if options.Title == nil {
 					return nil, errorDomain.NewError("タイトルが含まれていません")
 				}
@@ -76,7 +78,7 @@ func newRecurringSchedule(
 			}
 
 			// 訪問予定の場合
-			if schedule_type.Name == scheduleTypeDomain.ScheduleTypeVisit {
+			if schedule_type.Name == scheduleTypeDomain.Visit {
 
 				if options.VisitInfoID == nil {
 					return nil, errorDomain.NewError("訪問情報が含まれていません")
@@ -106,4 +108,32 @@ func newRecurringSchedule(
 	}
 
 	return recurringSchedule, nil
+}
+
+var RecurringScheduleRelationMappings = map[string]query.RelationMapping{
+	"recurring_rule": {
+		TableName:   "recurring_rules",
+		JoinKey:     "recurring_rules.id = recurring_schedules.recurring_rule_id",
+		FilterField: "recurring_rule.name",
+	},
+	"schedule_type": {
+		TableName:   "schedule_types",
+		JoinKey:     "schedule_types.id = recurring_schedules.schedule_type_id",
+		FilterField: "schedule_type.name",
+	},
+	"staff": {
+		TableName:   "users",
+		JoinKey:     "users.id = recurring_schedules.staff_id",
+		FilterField: "users.name",
+	},
+	"facility": {
+		TableName:   "facilities",
+		JoinKey:     "facilities.id = recurring_schedules.facility_id",
+		FilterField: "facilities.name",
+	},
+	"visit_info": {
+		TableName:   "visit_infos",
+		JoinKey:     "visit_infos.id = recurring_schedules.visit_info_id",
+		FilterField: "visit_info.name",
+	},
 }

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule.go
@@ -1,0 +1,109 @@
+package recurring_schedule
+
+import (
+	errorDomain "api-buddy/domain/error"
+	facilityDomain "api-buddy/domain/facility"
+	recurringRuleDomain "api-buddy/domain/schedule/recurring_rule"
+	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
+	userDomain "api-buddy/domain/user"
+	visitInfoDomain "api-buddy/domain/visit_info"
+	"time"
+)
+
+type Option struct {
+	VisitInfo   *visitInfoDomain.VisitInfo
+	VisitInfoID *string
+	Title       *string
+	Description *string
+}
+
+type RecurringSchedule struct {
+	ID              string
+	RecurringRule   *recurringRuleDomain.RecurringRule
+	RecurringRuleID string
+	ScheduleType    *scheduleTypeDomain.ScheduleType
+	ScheduleTypeID  string `gorm:"foreignKey:ID;references:ScheduleTypeID"`
+	Date            time.Time
+	StartTime       time.Time
+	EndTime         time.Time
+	IsOverTimeWork  bool
+	Staff           *userDomain.User
+	StaffID         string `gorm:"foreignKey:ID;references:StaffID"`
+	VisitInfo       *visitInfoDomain.VisitInfo
+	Facility        *facilityDomain.Facility
+	FacilityID      string
+	VisitInfoID     string
+	Title           string
+	Description     string
+}
+
+func newRecurringSchedule(
+	id string,
+	recurring_rule *recurringRuleDomain.RecurringRule,
+	schedule_type *scheduleTypeDomain.ScheduleType,
+	date time.Time,
+	start_time time.Time,
+	end_time time.Time,
+	is_over_time_work bool,
+	staff *userDomain.User,
+	facility *facilityDomain.Facility,
+	options *Option,
+) (*RecurringSchedule, error) {
+	recurringSchedule := &RecurringSchedule{
+		ID:              id,
+		RecurringRule:   recurring_rule,
+		RecurringRuleID: recurring_rule.ID,
+		ScheduleType:    schedule_type,
+		ScheduleTypeID:  schedule_type.ID,
+		Date:            date,
+		StartTime:       start_time,
+		EndTime:         end_time,
+		IsOverTimeWork:  is_over_time_work,
+		Staff:           staff,
+		StaffID:         staff.ID,
+		Facility:        facility,
+		FacilityID:      facility.ID,
+	}
+
+	if options != nil {
+		if options != nil {
+			// 通常予定の場合
+			if schedule_type.Name == scheduleTypeDomain.ScheduleTypeNormal {
+				if options.Title == nil {
+					return nil, errorDomain.NewError("タイトルが含まれていません")
+				}
+				recurringSchedule.Title = *options.Title
+			}
+
+			// 訪問予定の場合
+			if schedule_type.Name == scheduleTypeDomain.ScheduleTypeVisit {
+
+				if options.VisitInfoID == nil {
+					return nil, errorDomain.NewError("訪問情報が含まれていません")
+				}
+				recurringSchedule.VisitInfoID = *options.VisitInfoID
+				recurringSchedule.VisitInfo = options.VisitInfo
+			}
+
+			// 補足情報
+			if options.Description != nil {
+				recurringSchedule.Description = *options.Description
+			}
+		}
+		// 開始時間が17:00以降の場合
+		if recurringSchedule.StartTime.Hour() >= 17 {
+			recurringSchedule.IsOverTimeWork = true
+		}
+		// 終了時間が開始時間より前の場合
+		if recurringSchedule.EndTime.Before(recurringSchedule.StartTime) {
+			return nil, errorDomain.NewError("終了時間が開始時間より前です")
+		}
+
+		// 終了時間が開始時間と同じ場合
+		if recurringSchedule.EndTime.Equal(recurringSchedule.StartTime) {
+			return nil, errorDomain.NewError("終了時間が開始時間と同じです")
+		}
+	}
+
+	return recurringSchedule, nil
+}

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule.go
@@ -27,11 +27,11 @@ type RecurringSchedule struct {
 	StaffID                 string `gorm:"foreignKey::StaffID"`
 	Facility                *facilityDomain.Facility
 	FacilityID              string
-	VisitInfoID             string
+	VisitInfoID             *string
 	VisitInfo               *visitInfoDomain.VisitInfo `gorm:"foreignKey:VisitInfoID"`
 	Title                   string
 	Description             string
-	RecurringExclusionDates common.JSONSlice[int]
+	RecurringExclusionDates *common.JSONSlice[int]
 	common.CommonModel
 }
 
@@ -63,7 +63,7 @@ func WithVisitInfo(visitInfo *visitInfoDomain.VisitInfo) RecurringScheduleOption
 			return errorDomain.NewError("訪問情報が含まれていません")
 		}
 		s.VisitInfo = visitInfo
-		s.VisitInfoID = visitInfo.ID
+		s.VisitInfoID = &visitInfo.ID
 		return nil
 	}
 }
@@ -73,7 +73,7 @@ func WithRecurringExclusionDates(recurring_exclusion_dates common.JSONSlice[int]
 		if len(recurring_exclusion_dates) == 0 {
 			return errorDomain.NewError("除外日が含まれていません")
 		}
-		s.RecurringExclusionDates = recurring_exclusion_dates
+		s.RecurringExclusionDates = &recurring_exclusion_dates
 		return nil
 	}
 }
@@ -94,7 +94,7 @@ func NewRecurringSchedule(
 		scheduleType,
 		date,
 		startTime,
-		startTime,
+		endTime,
 		staff,
 		facility,
 		options...,
@@ -120,19 +120,24 @@ func newRecurringSchedule(
 	}
 
 	recurringSchedule := &RecurringSchedule{
-		ID:              id,
-		RecurringRule:   recurringRule,
-		RecurringRuleID: recurringRule.ID,
-		ScheduleType:    scheduleType,
-		ScheduleTypeID:  scheduleType.ID,
-		Date:            date,
-		StartTime:       startTime,
-		EndTime:         endTime,
-		IsOverTimeWork:  startTime.Hour() >= 17,
-		Staff:           staff,
-		StaffID:         staff.ID,
-		Facility:        facility,
-		FacilityID:      facility.ID,
+		ID:                      id,
+		RecurringRule:           recurringRule,
+		RecurringRuleID:         recurringRule.ID,
+		ScheduleType:            scheduleType,
+		ScheduleTypeID:          scheduleType.ID,
+		Date:                    date,
+		StartTime:               startTime,
+		EndTime:                 endTime,
+		IsOverTimeWork:          startTime.Hour() >= 17,
+		Staff:                   staff,
+		StaffID:                 staff.ID,
+		Facility:                facility,
+		FacilityID:              facility.ID,
+		VisitInfo:               nil,
+		VisitInfoID:             nil,
+		Title:                   "",
+		Description:             "",
+		RecurringExclusionDates: nil,
 	}
 
 	for _, option := range options {

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule.go
@@ -141,6 +141,14 @@ func newRecurringSchedule(
 		}
 	}
 
+	// 通常予定の場合、タイトルは必須
+	// 予定種別が通常の場合、タイトルは必須
+	if recurringSchedule.ScheduleType.Name == scheduleTypeDomain.Normal {
+		if recurringSchedule.Title == "" {
+			return nil, errorDomain.NewError("通常の予定の場合、タイトルは必須です")
+		}
+	}
+
 	return recurringSchedule, nil
 }
 

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule.go
@@ -1,109 +1,143 @@
 package recurring_schedule
 
 import (
+	"api-buddy/domain/common"
 	errorDomain "api-buddy/domain/error"
 	facilityDomain "api-buddy/domain/facility"
 	recurringRuleDomain "api-buddy/domain/schedule/recurring_rule"
 	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
 	userDomain "api-buddy/domain/user"
 	visitInfoDomain "api-buddy/domain/visit_info"
-	"time"
 
 	"github.com/Fukuemon/go-pkg/query"
+	"github.com/Fukuemon/go-pkg/ulid"
 )
 
-type Option struct {
-	VisitInfo   *visitInfoDomain.VisitInfo
-	VisitInfoID *string
-	Title       *string
-	Description *string
+type RecurringSchedule struct {
+	ID                      string                             `gorm:"primaryKey"`
+	RecurringRule           *recurringRuleDomain.RecurringRule `gorm:"foreignKey:RecurringRuleID"`
+	RecurringRuleID         string
+	ScheduleType            *scheduleTypeDomain.ScheduleType `gorm:"foreignKey:ScheduleTypeID"`
+	ScheduleTypeID          string
+	Date                    common.Date
+	StartTime               common.Time
+	EndTime                 common.Time
+	IsOverTimeWork          bool
+	Staff                   *userDomain.User
+	StaffID                 string `gorm:"foreignKey::StaffID"`
+	Facility                *facilityDomain.Facility
+	FacilityID              string
+	VisitInfoID             string
+	VisitInfo               *visitInfoDomain.VisitInfo `gorm:"foreignKey:VisitInfoID"`
+	Title                   string
+	Description             string
+	RecurringExclusionDates common.JSONSlice[int]
+	common.CommonModel
 }
 
-type RecurringSchedule struct {
-	ID              string
-	RecurringRule   *recurringRuleDomain.RecurringRule
-	RecurringRuleID string
-	ScheduleType    *scheduleTypeDomain.ScheduleType
-	ScheduleTypeID  string `gorm:"foreignKey:ID;references:ScheduleTypeID"`
-	Date            time.Time
-	StartTime       time.Time
-	EndTime         time.Time
-	IsOverTimeWork  bool
-	Staff           *userDomain.User
-	StaffID         string `gorm:"foreignKey:ID;references:StaffID"`
-	VisitInfo       *visitInfoDomain.VisitInfo
-	Facility        *facilityDomain.Facility
-	FacilityID      string
-	VisitInfoID     string
-	Title           string
-	Description     string
+type RecurringScheduleOption func(*RecurringSchedule) error
+
+func WithTitle(title string) RecurringScheduleOption {
+	return func(s *RecurringSchedule) error {
+		if title == "" {
+			return errorDomain.NewError("タイトルが含まれていません")
+		}
+		s.Title = title
+		return nil
+	}
+}
+
+func WithDescription(description string) RecurringScheduleOption {
+	return func(s *RecurringSchedule) error {
+		if description == "" {
+			return errorDomain.NewError("説明が含まれていません")
+		}
+		s.Description = description
+		return nil
+	}
+}
+
+func WithVisitInfo(visitInfo *visitInfoDomain.VisitInfo) RecurringScheduleOption {
+	return func(s *RecurringSchedule) error {
+		if visitInfo == nil {
+			return errorDomain.NewError("訪問情報が含まれていません")
+		}
+		s.VisitInfo = visitInfo
+		s.VisitInfoID = visitInfo.ID
+		return nil
+	}
+}
+
+func WithRecurringExclusionDates(recurring_exclusion_dates common.JSONSlice[int]) RecurringScheduleOption {
+	return func(s *RecurringSchedule) error {
+		if len(recurring_exclusion_dates) == 0 {
+			return errorDomain.NewError("除外日が含まれていません")
+		}
+		s.RecurringExclusionDates = recurring_exclusion_dates
+		return nil
+	}
+}
+
+func NewRecurringSchedule(
+	recurringRule *recurringRuleDomain.RecurringRule,
+	scheduleType *scheduleTypeDomain.ScheduleType,
+	date common.Date,
+	startTime common.Time,
+	endTime common.Time,
+	staff *userDomain.User,
+	facility *facilityDomain.Facility,
+	options ...RecurringScheduleOption,
+) (*RecurringSchedule, error) {
+	return newRecurringSchedule(
+		ulid.NewULID(),
+		recurringRule,
+		scheduleType,
+		date,
+		startTime,
+		startTime,
+		staff,
+		facility,
+		options...,
+	)
 }
 
 func newRecurringSchedule(
 	id string,
-	recurring_rule *recurringRuleDomain.RecurringRule,
-	schedule_type *scheduleTypeDomain.ScheduleType,
-	date time.Time,
-	start_time time.Time,
-	end_time time.Time,
-	is_over_time_work bool,
+	recurringRule *recurringRuleDomain.RecurringRule,
+	scheduleType *scheduleTypeDomain.ScheduleType,
+	date common.Date,
+	startTime common.Time,
+	endTime common.Time,
 	staff *userDomain.User,
 	facility *facilityDomain.Facility,
-	options *Option,
+	options ...RecurringScheduleOption,
 ) (*RecurringSchedule, error) {
+	if endTime.Before(startTime.Time) {
+		return nil, errorDomain.NewError("終了時間が開始時間より前です")
+	}
+	if endTime.Equal(startTime.Time) {
+		return nil, errorDomain.NewError("終了時間が開始時間と同じです")
+	}
+
 	recurringSchedule := &RecurringSchedule{
 		ID:              id,
-		RecurringRule:   recurring_rule,
-		RecurringRuleID: recurring_rule.ID,
-		ScheduleType:    schedule_type,
-		ScheduleTypeID:  schedule_type.ID,
+		RecurringRule:   recurringRule,
+		RecurringRuleID: recurringRule.ID,
+		ScheduleType:    scheduleType,
+		ScheduleTypeID:  scheduleType.ID,
 		Date:            date,
-		StartTime:       start_time,
-		EndTime:         end_time,
-		IsOverTimeWork:  is_over_time_work,
+		StartTime:       startTime,
+		EndTime:         endTime,
+		IsOverTimeWork:  startTime.Hour() >= 17,
 		Staff:           staff,
 		StaffID:         staff.ID,
 		Facility:        facility,
 		FacilityID:      facility.ID,
 	}
 
-	if options != nil {
-		if options != nil {
-			// 通常予定の場合
-			if schedule_type.Name == scheduleTypeDomain.Normal {
-				if options.Title == nil {
-					return nil, errorDomain.NewError("タイトルが含まれていません")
-				}
-				recurringSchedule.Title = *options.Title
-			}
-
-			// 訪問予定の場合
-			if schedule_type.Name == scheduleTypeDomain.Visit {
-
-				if options.VisitInfoID == nil {
-					return nil, errorDomain.NewError("訪問情報が含まれていません")
-				}
-				recurringSchedule.VisitInfoID = *options.VisitInfoID
-				recurringSchedule.VisitInfo = options.VisitInfo
-			}
-
-			// 補足情報
-			if options.Description != nil {
-				recurringSchedule.Description = *options.Description
-			}
-		}
-		// 開始時間が17:00以降の場合
-		if recurringSchedule.StartTime.Hour() >= 17 {
-			recurringSchedule.IsOverTimeWork = true
-		}
-		// 終了時間が開始時間より前の場合
-		if recurringSchedule.EndTime.Before(recurringSchedule.StartTime) {
-			return nil, errorDomain.NewError("終了時間が開始時間より前です")
-		}
-
-		// 終了時間が開始時間と同じ場合
-		if recurringSchedule.EndTime.Equal(recurringSchedule.StartTime) {
-			return nil, errorDomain.NewError("終了時間が開始時間と同じです")
+	for _, option := range options {
+		if err := option(recurringSchedule); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule_repository.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule_repository.go
@@ -1,9 +1,13 @@
 package recurring_schedule
 
-import "github.com/Fukuemon/go-pkg/query"
+import (
+	"context"
+
+	"github.com/Fukuemon/go-pkg/query"
+)
 
 type RecurringScheduleRepository interface {
-	FindByFacilityID(facility_id string, filters []query.Filter, sort query.SortOption) ([]*RecurringSchedule, error)
-	FindByID(id string) (*RecurringSchedule, error)
-	Create(recurring_schedule *RecurringSchedule) error
+	FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*RecurringSchedule, error)
+	FindByID(ctx context.Context, id string) (*RecurringSchedule, error)
+	Create(ctx context.Context, recurring_schedule *RecurringSchedule) error
 }

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule_repository.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule_repository.go
@@ -1,0 +1,9 @@
+package recurring_schedule
+
+import "github.com/Fukuemon/go-pkg/query"
+
+type RecurringScheduleRepository interface {
+	FindByFacilityID(facility_id string, filters []query.Filter, sort query.SortOption) ([]*RecurringSchedule, error)
+	FindByID(id string) (*RecurringSchedule, error)
+	Create(recurring_schedule *RecurringSchedule) error
+}

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule_repository.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule_repository.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/Fukuemon/go-pkg/query"
+	"gorm.io/gorm"
 )
 
 type RecurringScheduleRepository interface {
 	FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*RecurringSchedule, error)
 	FindByID(ctx context.Context, id string) (*RecurringSchedule, error)
-	Create(ctx context.Context, recurring_schedule *RecurringSchedule) error
+	Create(ctx context.Context, tx *gorm.DB, recurring_schedule *RecurringSchedule) error
 }

--- a/internal/domain/schedule/schedule.go
+++ b/internal/domain/schedule/schedule.go
@@ -1,0 +1,156 @@
+package schedule
+
+import (
+	errorDomain "api-buddy/domain/error"
+	facilityDomain "api-buddy/domain/facility"
+	scheduleCancelDomain "api-buddy/domain/schedule/schedule_cancel"
+	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
+	userDomain "api-buddy/domain/user"
+	visitInfoDomain "api-buddy/domain/visit_info"
+	"time"
+
+	"github.com/Fukuemon/go-pkg/ulid"
+)
+
+type Option struct {
+	VisitInfo             *visitInfoDomain.VisitInfo
+	VisitInfoID           *string
+	Title                 *string
+	RecurringScheduleID   *string
+	BeforeChangeDate      *time.Time
+	BeforeChangeStartTime *time.Time
+	Description           *string
+	ScheduleCancel        *scheduleCancelDomain.ScheduleCancel
+	ScheduleCancelID      *string
+}
+
+type Schedule struct {
+	ID                    string
+	ScheduleType          *scheduleTypeDomain.ScheduleType
+	ScheduleTypeID        string `gorm:"foreignKey:ID;references:ScheduleTypeID"`
+	Date                  time.Time
+	StartTime             time.Time
+	EndTime               time.Time
+	IsOverTimeWork        bool
+	Staff                 *userDomain.User
+	StaffID               string `gorm:"foreignKey:ID;references:StaffID"`
+	Facility              *facilityDomain.Facility
+	FacilityID            string
+	Title                 string
+	VisitInfo             *visitInfoDomain.VisitInfo
+	VisitInfoID           string `gorm:"foreignKey:ID;references:VisitInfoID"`
+	RecurringScheduleID   string `gorm:"foreignKey:ID;references:RecurringScheduleID"`
+	BeforeChangeDate      *time.Time
+	BeforeChangeStartTime *time.Time
+	Description           string
+	ScheduleCancel        *scheduleCancelDomain.ScheduleCancel
+	ScheduleCancelID      string
+}
+
+func NewSchedule(
+	schedule_type *scheduleTypeDomain.ScheduleType,
+	date time.Time,
+	start_time time.Time,
+	end_time time.Time,
+	is_over_time_work bool,
+	staff *userDomain.User,
+	facility *facilityDomain.Facility,
+	options *Option,
+) (*Schedule, error) {
+	return newSchedule(
+		ulid.NewULID(),
+		schedule_type,
+		date,
+		start_time,
+		end_time,
+		is_over_time_work,
+		staff,
+		facility,
+		options,
+	)
+}
+
+func newSchedule(
+	id string,
+	schedule_type *scheduleTypeDomain.ScheduleType,
+	date time.Time,
+	start_time time.Time,
+	end_time time.Time,
+	is_over_time_work bool,
+	staff *userDomain.User,
+	facility *facilityDomain.Facility,
+	options *Option,
+) (*Schedule, error) {
+	schedule := &Schedule{
+		ID:             id,
+		ScheduleType:   schedule_type,
+		Date:           date,
+		StartTime:      start_time,
+		EndTime:        end_time,
+		IsOverTimeWork: is_over_time_work,
+		Staff:          staff,
+		StaffID:        staff.ID,
+		Facility:       facility,
+		FacilityID:     facility.ID,
+	}
+
+	if options != nil {
+		// 通常予定の場合
+		if schedule_type.Name == scheduleTypeDomain.ScheduleTypeNormal {
+			if options.Title == nil {
+				return nil, errorDomain.NewError("タイトルが含まれていません")
+			}
+			schedule.Title = *options.Title
+		}
+
+		// 訪問予定の場合
+		if schedule_type.Name == scheduleTypeDomain.ScheduleTypeVisit {
+
+			if options.VisitInfoID == nil {
+				return nil, errorDomain.NewError("訪問情報が含まれていません")
+			}
+			schedule.VisitInfoID = *options.VisitInfoID
+			schedule.VisitInfo = options.VisitInfo
+		}
+
+		// 繰り返し予定からの変更だった場合
+		if options.RecurringScheduleID != nil {
+			schedule.RecurringScheduleID = *options.RecurringScheduleID
+			if options.BeforeChangeDate == nil {
+				return nil, errorDomain.NewError("変更前の日付が含まれていません")
+			}
+			if options.BeforeChangeStartTime == nil {
+				return nil, errorDomain.NewError("変更前の開始時間が含まれていません")
+			}
+			schedule.BeforeChangeDate = options.BeforeChangeDate
+			schedule.BeforeChangeStartTime = options.BeforeChangeStartTime
+		}
+
+		// 補足情報
+		if options.Description != nil {
+			schedule.Description = *options.Description
+		}
+
+		// 予定キャンセル情報
+		if options.ScheduleCancelID != nil {
+			schedule.ScheduleCancelID = *options.ScheduleCancelID
+			schedule.ScheduleCancel = options.ScheduleCancel
+		}
+	}
+	// 開始時間が17:00以降の場合
+	if schedule.StartTime.Hour() >= 17 {
+		schedule.IsOverTimeWork = true
+	}
+
+	// 終了時間が開始時間より前の場合
+	if schedule.EndTime.Before(schedule.StartTime) {
+		return nil, errorDomain.NewError("終了時間が開始時間より前です")
+	}
+
+	// 終了時間が開始時間と同じ場合
+	if schedule.EndTime.Equal(schedule.StartTime) {
+		return nil, errorDomain.NewError("終了時間が開始時間と同じです")
+	}
+
+	return schedule, nil
+}

--- a/internal/domain/schedule/schedule.go
+++ b/internal/domain/schedule/schedule.go
@@ -15,27 +15,25 @@ import (
 )
 
 type Schedule struct {
-	ID                    string                           `gorm:"primaryKey"`
-	ScheduleType          *scheduleTypeDomain.ScheduleType `gorm:"foreignKey:ScheduleTypeID"`
-	ScheduleTypeID        string
-	Date                  common.Date
-	StartTime             common.Time
-	EndTime               common.Time
-	IsOverTimeWork        bool
-	Staff                 *userDomain.User `gorm:"foreignKey:StaffID"`
-	StaffID               string
-	Facility              *facilityDomain.Facility `gorm:"foreignKey:FacilityID"`
-	FacilityID            string
-	Title                 string
-	VisitInfo             *visitInfoDomain.VisitInfo `gorm:"foreignKey:VisitInfoID"`
-	VisitInfoID           string
-	RecurringSchedule     *recurringScheduleDomain.RecurringSchedule `gorm:"foreignKey:RecurringScheduleID"`
-	RecurringScheduleID   string
-	BeforeChangeDate      *common.Date
-	BeforeChangeStartTime *common.Time
-	Description           string
-	ScheduleCancel        *scheduleCancelDomain.ScheduleCancel `gorm:"foreignKey:ScheduleCancelID"`
-	ScheduleCancelID      string
+	ID                  string                           `gorm:"primaryKey"`
+	ScheduleType        *scheduleTypeDomain.ScheduleType `gorm:"foreignKey:ScheduleTypeID"`
+	ScheduleTypeID      string
+	Date                common.Date
+	StartTime           common.Time
+	EndTime             common.Time
+	IsOverTimeWork      bool
+	Staff               *userDomain.User `gorm:"foreignKey:StaffID"`
+	StaffID             string
+	Facility            *facilityDomain.Facility `gorm:"foreignKey:FacilityID"`
+	FacilityID          string
+	Title               string
+	VisitInfo           *visitInfoDomain.VisitInfo `gorm:"foreignKey:VisitInfoID"`
+	VisitInfoID         string
+	RecurringSchedule   *recurringScheduleDomain.RecurringSchedule `gorm:"foreignKey:RecurringScheduleID"`
+	RecurringScheduleID string
+	Description         string
+	ScheduleCancel      *scheduleCancelDomain.ScheduleCancel `gorm:"foreignKey:ScheduleCancelID"`
+	ScheduleCancelID    string
 	common.CommonModel
 }
 
@@ -64,17 +62,13 @@ func WithVisitInfo(visitInfo *visitInfoDomain.VisitInfo) ScheduleOption {
 
 func WithRecurringSchedule(
 	recurringSchedule *recurringScheduleDomain.RecurringSchedule,
-	beforeChangeDate *common.Date,
-	beforeChangeStartTime *common.Time,
 ) ScheduleOption {
 	return func(s *Schedule) error {
-		if recurringSchedule == nil || beforeChangeDate == nil || beforeChangeStartTime == nil {
+		if recurringSchedule == nil {
 			return errorDomain.NewError("繰り返し予定の情報が含まれていません")
 		}
 		s.RecurringSchedule = recurringSchedule
 		s.RecurringScheduleID = recurringSchedule.ID
-		s.BeforeChangeDate = beforeChangeDate
-		s.BeforeChangeStartTime = beforeChangeStartTime
 		return nil
 	}
 }

--- a/internal/domain/schedule/schedule.go
+++ b/internal/domain/schedule/schedule.go
@@ -130,6 +130,13 @@ func NewSchedule(
 		}
 	}
 
+	// 予定種別が通常の場合、タイトルは必須
+	if schedule.ScheduleType.Name == scheduleTypeDomain.Normal {
+		if schedule.Title == "" {
+			return nil, errorDomain.NewError("通常の予定の場合、タイトルは必須です")
+		}
+	}
+
 	common.InitializeCommonModel(&schedule.CommonModel)
 	return schedule, nil
 }

--- a/internal/domain/schedule/schedule.go
+++ b/internal/domain/schedule/schedule.go
@@ -28,12 +28,12 @@ type Schedule struct {
 	FacilityID          string
 	Title               string
 	VisitInfo           *visitInfoDomain.VisitInfo `gorm:"foreignKey:VisitInfoID"`
-	VisitInfoID         string
+	VisitInfoID         *string
 	RecurringSchedule   *recurringScheduleDomain.RecurringSchedule `gorm:"foreignKey:RecurringScheduleID"`
-	RecurringScheduleID string
+	RecurringScheduleID *string
 	Description         string
 	ScheduleCancel      *scheduleCancelDomain.ScheduleCancel `gorm:"foreignKey:ScheduleCancelID"`
-	ScheduleCancelID    string
+	ScheduleCancelID    *string
 	common.CommonModel
 }
 
@@ -42,7 +42,8 @@ type ScheduleOption func(*Schedule) error
 func WithTitle(title string) ScheduleOption {
 	return func(s *Schedule) error {
 		if title == "" {
-			return errorDomain.NewError("タイトルが含まれていません")
+			err := errorDomain.NewError("タイトルが含まれていません")
+			return errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 		}
 		s.Title = title
 		return nil
@@ -52,10 +53,11 @@ func WithTitle(title string) ScheduleOption {
 func WithVisitInfo(visitInfo *visitInfoDomain.VisitInfo) ScheduleOption {
 	return func(s *Schedule) error {
 		if visitInfo == nil {
-			return errorDomain.NewError("訪問情報が含まれていません")
+			err := errorDomain.NewError("訪問情報が含まれていません")
+			return errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 		}
 		s.VisitInfo = visitInfo
-		s.VisitInfoID = visitInfo.ID
+		s.VisitInfoID = &visitInfo.ID
 		return nil
 	}
 }
@@ -65,10 +67,11 @@ func WithRecurringSchedule(
 ) ScheduleOption {
 	return func(s *Schedule) error {
 		if recurringSchedule == nil {
-			return errorDomain.NewError("繰り返し予定の情報が含まれていません")
+			err := errorDomain.NewError("繰り返し予定の情報が含まれていません")
+			return errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 		}
 		s.RecurringSchedule = recurringSchedule
-		s.RecurringScheduleID = recurringSchedule.ID
+		s.RecurringScheduleID = &recurringSchedule.ID
 		return nil
 	}
 }
@@ -83,10 +86,11 @@ func WithDescription(description string) ScheduleOption {
 func WithScheduleCancel(scheduleCancel *scheduleCancelDomain.ScheduleCancel) ScheduleOption {
 	return func(s *Schedule) error {
 		if scheduleCancel == nil {
-			return errorDomain.NewError("キャンセル情報が含まれていません")
+			err := errorDomain.NewError("キャンセル情報が含まれていません")
+			return errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 		}
 		s.ScheduleCancel = scheduleCancel
-		s.ScheduleCancelID = scheduleCancel.ID
+		s.ScheduleCancelID = &scheduleCancel.ID
 		return nil
 	}
 }
@@ -103,24 +107,33 @@ func NewSchedule(
 ) (*Schedule, error) {
 	// Validate start and end times
 	if endTime.Before(startTime.Time) {
-		return nil, errorDomain.NewError("終了時間が開始時間より前です")
+		err := errorDomain.NewError("終了時間が開始時間より前です")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 	}
 	if endTime.Equal(startTime.Time) {
-		return nil, errorDomain.NewError("終了時間が開始時間と同じです")
+		err := errorDomain.NewError("終了時間が開始時間と同じです")
+		return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 	}
 
 	schedule := &Schedule{
-		ID:             ulid.NewULID(),
-		ScheduleType:   scheduleType,
-		ScheduleTypeID: scheduleType.ID,
-		Date:           date,
-		StartTime:      startTime,
-		EndTime:        endTime,
-		IsOverTimeWork: startTime.Hour() >= 17,
-		Staff:          staff,
-		StaffID:        staff.ID,
-		Facility:       facility,
-		FacilityID:     facility.ID,
+		ID:                  ulid.NewULID(),
+		ScheduleType:        scheduleType,
+		ScheduleTypeID:      scheduleType.ID,
+		Date:                date,
+		StartTime:           startTime,
+		EndTime:             endTime,
+		IsOverTimeWork:      startTime.Hour() >= 17,
+		Staff:               staff,
+		StaffID:             staff.ID,
+		Facility:            facility,
+		FacilityID:          facility.ID,
+		RecurringSchedule:   nil,
+		RecurringScheduleID: nil,
+		VisitInfo:           nil,
+		VisitInfoID:         nil,
+		Description:         "",
+		ScheduleCancel:      nil,
+		ScheduleCancelID:    nil,
 	}
 
 	// Apply options
@@ -133,7 +146,16 @@ func NewSchedule(
 	// 予定種別が通常の場合、タイトルは必須
 	if schedule.ScheduleType.Name == scheduleTypeDomain.Normal {
 		if schedule.Title == "" {
-			return nil, errorDomain.NewError("通常の予定の場合、タイトルは必須です")
+			err := errorDomain.NewError("通常の予定の場合、タイトルは必須です")
+			return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+		}
+	}
+
+	// 予定種別が訪問の場合、訪問情報は必須
+	if schedule.ScheduleType.Name == scheduleTypeDomain.Visit {
+		if schedule.VisitInfo == nil {
+			err := errorDomain.NewError("訪問の予定の場合、訪問情報は必須です")
+			return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 		}
 	}
 

--- a/internal/domain/schedule/schedule.go
+++ b/internal/domain/schedule/schedule.go
@@ -1,6 +1,7 @@
 package schedule
 
 import (
+	"api-buddy/domain/common"
 	errorDomain "api-buddy/domain/error"
 	facilityDomain "api-buddy/domain/facility"
 	recurringScheduleDomain "api-buddy/domain/schedule/recurring_schedule"
@@ -8,155 +9,134 @@ import (
 	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
 	userDomain "api-buddy/domain/user"
 	visitInfoDomain "api-buddy/domain/visit_info"
-	"time"
 
 	"github.com/Fukuemon/go-pkg/query"
 	"github.com/Fukuemon/go-pkg/ulid"
 )
 
-type Option struct {
-	VisitInfo             *visitInfoDomain.VisitInfo
-	VisitInfoID           *string
-	Title                 *string
-	RecurringScheduleID   *string
-	RecurringSchedule     *recurringScheduleDomain.RecurringSchedule
-	BeforeChangeDate      *time.Time
-	BeforeChangeStartTime *time.Time
-	Description           *string
-	ScheduleCancel        *scheduleCancelDomain.ScheduleCancel
-	ScheduleCancelID      *string
-}
-
 type Schedule struct {
-	ID                    string
-	ScheduleType          *scheduleTypeDomain.ScheduleType
-	ScheduleTypeID        string `gorm:"foreignKey:ID;references:ScheduleTypeID"`
-	Date                  time.Time
-	StartTime             time.Time
-	EndTime               time.Time
+	ID                    string                           `gorm:"primaryKey"`
+	ScheduleType          *scheduleTypeDomain.ScheduleType `gorm:"foreignKey:ScheduleTypeID"`
+	ScheduleTypeID        string
+	Date                  common.Date
+	StartTime             common.Time
+	EndTime               common.Time
 	IsOverTimeWork        bool
-	Staff                 *userDomain.User
-	StaffID               string `gorm:"foreignKey:ID;references:StaffID"`
-	Facility              *facilityDomain.Facility
-	FacilityID            string `gorm:"foreignKey:ID;references:FacilityID"`
+	Staff                 *userDomain.User `gorm:"foreignKey:StaffID"`
+	StaffID               string
+	Facility              *facilityDomain.Facility `gorm:"foreignKey:FacilityID"`
+	FacilityID            string
 	Title                 string
-	VisitInfo             *visitInfoDomain.VisitInfo
-	VisitInfoID           string `gorm:"foreignKey:ID;references:VisitInfoID"`
-	RecurringSchedule     *recurringScheduleDomain.RecurringSchedule
-	RecurringScheduleID   string `gorm:"foreignKey:ID;references:RecurringScheduleID"`
-	BeforeChangeDate      *time.Time
-	BeforeChangeStartTime *time.Time
+	VisitInfo             *visitInfoDomain.VisitInfo `gorm:"foreignKey:VisitInfoID"`
+	VisitInfoID           string
+	RecurringSchedule     *recurringScheduleDomain.RecurringSchedule `gorm:"foreignKey:RecurringScheduleID"`
+	RecurringScheduleID   string
+	BeforeChangeDate      *common.Date
+	BeforeChangeStartTime *common.Time
 	Description           string
-	ScheduleCancel        *scheduleCancelDomain.ScheduleCancel
-	ScheduleCancelID      string `gorm:"foreignKey:ID;references:ScheduleCancelID"`
+	ScheduleCancel        *scheduleCancelDomain.ScheduleCancel `gorm:"foreignKey:ScheduleCancelID"`
+	ScheduleCancelID      string
+	common.CommonModel
 }
 
+type ScheduleOption func(*Schedule) error
+
+func WithTitle(title string) ScheduleOption {
+	return func(s *Schedule) error {
+		if title == "" {
+			return errorDomain.NewError("タイトルが含まれていません")
+		}
+		s.Title = title
+		return nil
+	}
+}
+
+func WithVisitInfo(visitInfo *visitInfoDomain.VisitInfo) ScheduleOption {
+	return func(s *Schedule) error {
+		if visitInfo == nil {
+			return errorDomain.NewError("訪問情報が含まれていません")
+		}
+		s.VisitInfo = visitInfo
+		s.VisitInfoID = visitInfo.ID
+		return nil
+	}
+}
+
+func WithRecurringSchedule(
+	recurringSchedule *recurringScheduleDomain.RecurringSchedule,
+	beforeChangeDate *common.Date,
+	beforeChangeStartTime *common.Time,
+) ScheduleOption {
+	return func(s *Schedule) error {
+		if recurringSchedule == nil || beforeChangeDate == nil || beforeChangeStartTime == nil {
+			return errorDomain.NewError("繰り返し予定の情報が含まれていません")
+		}
+		s.RecurringSchedule = recurringSchedule
+		s.RecurringScheduleID = recurringSchedule.ID
+		s.BeforeChangeDate = beforeChangeDate
+		s.BeforeChangeStartTime = beforeChangeStartTime
+		return nil
+	}
+}
+
+func WithDescription(description string) ScheduleOption {
+	return func(s *Schedule) error {
+		s.Description = description
+		return nil
+	}
+}
+
+func WithScheduleCancel(scheduleCancel *scheduleCancelDomain.ScheduleCancel) ScheduleOption {
+	return func(s *Schedule) error {
+		if scheduleCancel == nil {
+			return errorDomain.NewError("キャンセル情報が含まれていません")
+		}
+		s.ScheduleCancel = scheduleCancel
+		s.ScheduleCancelID = scheduleCancel.ID
+		return nil
+	}
+}
+
+// NewSchedule creates a new schedule instance
 func NewSchedule(
-	schedule_type *scheduleTypeDomain.ScheduleType,
-	date time.Time,
-	start_time time.Time,
-	end_time time.Time,
-	is_over_time_work bool,
+	scheduleType *scheduleTypeDomain.ScheduleType,
+	date common.Date,
+	startTime common.Time,
+	endTime common.Time,
 	staff *userDomain.User,
 	facility *facilityDomain.Facility,
-	options *Option,
+	options ...ScheduleOption,
 ) (*Schedule, error) {
-	return newSchedule(
-		ulid.NewULID(),
-		schedule_type,
-		date,
-		start_time,
-		end_time,
-		is_over_time_work,
-		staff,
-		facility,
-		options,
-	)
-}
+	// Validate start and end times
+	if endTime.Before(startTime.Time) {
+		return nil, errorDomain.NewError("終了時間が開始時間より前です")
+	}
+	if endTime.Equal(startTime.Time) {
+		return nil, errorDomain.NewError("終了時間が開始時間と同じです")
+	}
 
-func newSchedule(
-	id string,
-	schedule_type *scheduleTypeDomain.ScheduleType,
-	date time.Time,
-	start_time time.Time,
-	end_time time.Time,
-	is_over_time_work bool,
-	staff *userDomain.User,
-	facility *facilityDomain.Facility,
-	options *Option,
-) (*Schedule, error) {
 	schedule := &Schedule{
-		ID:             id,
-		ScheduleType:   schedule_type,
+		ID:             ulid.NewULID(),
+		ScheduleType:   scheduleType,
+		ScheduleTypeID: scheduleType.ID,
 		Date:           date,
-		StartTime:      start_time,
-		EndTime:        end_time,
-		IsOverTimeWork: is_over_time_work,
+		StartTime:      startTime,
+		EndTime:        endTime,
+		IsOverTimeWork: startTime.Hour() >= 17,
 		Staff:          staff,
 		StaffID:        staff.ID,
 		Facility:       facility,
 		FacilityID:     facility.ID,
 	}
 
-	if options != nil {
-		// 通常予定の場合
-		if schedule_type.Name == scheduleTypeDomain.Normal {
-			if options.Title == nil {
-				return nil, errorDomain.NewError("タイトルが含まれていません")
-			}
-			schedule.Title = *options.Title
-		}
-
-		// 訪問予定の場合
-		if schedule_type.Name == scheduleTypeDomain.Visit {
-
-			if options.VisitInfoID == nil {
-				return nil, errorDomain.NewError("訪問情報が含まれていません")
-			}
-			schedule.VisitInfoID = *options.VisitInfoID
-			schedule.VisitInfo = options.VisitInfo
-		}
-
-		// 繰り返し予定からの変更だった場合
-		if options.RecurringScheduleID != nil {
-			schedule.RecurringScheduleID = *options.RecurringScheduleID
-			if options.BeforeChangeDate == nil {
-				return nil, errorDomain.NewError("変更前の日付が含まれていません")
-			}
-			if options.BeforeChangeStartTime == nil {
-				return nil, errorDomain.NewError("変更前の開始時間が含まれていません")
-			}
-			schedule.BeforeChangeDate = options.BeforeChangeDate
-			schedule.BeforeChangeStartTime = options.BeforeChangeStartTime
-			schedule.RecurringSchedule = options.RecurringSchedule
-		}
-
-		// 補足情報
-		if options.Description != nil {
-			schedule.Description = *options.Description
-		}
-
-		// 予定キャンセル情報
-		if options.ScheduleCancelID != nil {
-			schedule.ScheduleCancelID = *options.ScheduleCancelID
-			schedule.ScheduleCancel = options.ScheduleCancel
+	// Apply options
+	for _, option := range options {
+		if err := option(schedule); err != nil {
+			return nil, err
 		}
 	}
-	// 開始時間が17:00以降の場合
-	if schedule.StartTime.Hour() >= 17 {
-		schedule.IsOverTimeWork = true
-	}
 
-	// 終了時間が開始時間より前の場合
-	if schedule.EndTime.Before(schedule.StartTime) {
-		return nil, errorDomain.NewError("終了時間が開始時間より前です")
-	}
-
-	// 終了時間が開始時間と同じ場合
-	if schedule.EndTime.Equal(schedule.StartTime) {
-		return nil, errorDomain.NewError("終了時間が開始時間と同じです")
-	}
-
+	common.InitializeCommonModel(&schedule.CommonModel)
 	return schedule, nil
 }
 

--- a/internal/domain/schedule/schedule_cancel/schedule_cancel.go
+++ b/internal/domain/schedule/schedule_cancel/schedule_cancel.go
@@ -1,0 +1,29 @@
+package schedule_cancel
+
+import (
+	"api-buddy/domain/common"
+
+	"github.com/Fukuemon/go-pkg/ulid"
+)
+
+type ScheduleCancel struct {
+	ID         string
+	ScheduleID string
+	Reason     string
+	common.CommonModel
+}
+
+func NewScheduleCancel(schedule_id string, reason string) (*ScheduleCancel, error) {
+	return newScheduleCancel(ulid.NewULID(), schedule_id, reason)
+}
+
+func newScheduleCancel(id string, schedule_id string, reason string) (*ScheduleCancel, error) {
+	scheduleCancel := &ScheduleCancel{
+		ID:         id,
+		ScheduleID: schedule_id,
+		Reason:     reason,
+	}
+
+	common.InitializeCommonModel(&scheduleCancel.CommonModel)
+	return scheduleCancel, nil
+}

--- a/internal/domain/schedule/schedule_cancel/schedule_cancel_repository.go
+++ b/internal/domain/schedule/schedule_cancel/schedule_cancel_repository.go
@@ -1,0 +1,8 @@
+package schedule_cancel
+
+import "context"
+
+type ScheduleCancelRepository interface {
+	FindByID(ctx context.Context, id string) (*ScheduleCancel, error)
+	Create(ctx context.Context, schedule_cancel *ScheduleCancel) error
+}

--- a/internal/domain/schedule/schedule_repository.go
+++ b/internal/domain/schedule/schedule_repository.go
@@ -1,0 +1,13 @@
+package schedule
+
+import (
+	"context"
+
+	"github.com/Fukuemon/go-pkg/query"
+)
+
+type ScheduleRepository interface {
+	FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*Schedule, error)
+	FindByID(ctx context.Context, id string) (*Schedule, error)
+	Create(ctx context.Context, schedule *Schedule) error
+}

--- a/internal/domain/schedule/schedule_repository.go
+++ b/internal/domain/schedule/schedule_repository.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/Fukuemon/go-pkg/query"
+	"gorm.io/gorm"
 )
 
 type ScheduleRepository interface {
 	FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*Schedule, error)
 	FindByID(ctx context.Context, id string) (*Schedule, error)
-	Create(ctx context.Context, schedule *Schedule) error
+	Create(ctx context.Context, tx *gorm.DB, schedule *Schedule) error
 }

--- a/internal/domain/schedule/schedule_type/schedule_type.go
+++ b/internal/domain/schedule/schedule_type/schedule_type.go
@@ -7,14 +7,13 @@ import (
 type ScheduleTypeEnum string
 
 const (
-	ScheduleTypeNormal ScheduleTypeEnum = "通常"
-	ScheduleTypeVisit  ScheduleTypeEnum = "訪問"
+	Normal ScheduleTypeEnum = "通常"
+	Visit  ScheduleTypeEnum = "訪問"
 )
 
 type ScheduleType struct {
-	ID         string `grom:"primaryKey"`
-	Name       ScheduleTypeEnum
-	FacilityID string
+	ID   string `grom:"primaryKey"`
+	Name ScheduleTypeEnum
 }
 
 func NewScheduleType(name ScheduleTypeEnum, facility_id string) *ScheduleType {
@@ -23,8 +22,7 @@ func NewScheduleType(name ScheduleTypeEnum, facility_id string) *ScheduleType {
 
 func newScheduleType(id string, name ScheduleTypeEnum, facility_id string) *ScheduleType {
 	return &ScheduleType{
-		ID:         id,
-		Name:       name,
-		FacilityID: facility_id,
+		ID:   id,
+		Name: name,
 	}
 }

--- a/internal/domain/schedule/schedule_type/schedule_type.go
+++ b/internal/domain/schedule/schedule_type/schedule_type.go
@@ -1,0 +1,30 @@
+package schedule_type
+
+import (
+	"github.com/Fukuemon/go-pkg/ulid"
+)
+
+type ScheduleTypeEnum string
+
+const (
+	ScheduleTypeNormal ScheduleTypeEnum = "通常"
+	ScheduleTypeVisit  ScheduleTypeEnum = "訪問"
+)
+
+type ScheduleType struct {
+	ID         string `grom:"primaryKey"`
+	Name       ScheduleTypeEnum
+	FacilityID string
+}
+
+func NewScheduleType(name ScheduleTypeEnum, facility_id string) *ScheduleType {
+	return newScheduleType(ulid.NewULID(), name, facility_id)
+}
+
+func newScheduleType(id string, name ScheduleTypeEnum, facility_id string) *ScheduleType {
+	return &ScheduleType{
+		ID:         id,
+		Name:       name,
+		FacilityID: facility_id,
+	}
+}

--- a/internal/domain/schedule/schedule_type/schedule_type.go
+++ b/internal/domain/schedule/schedule_type/schedule_type.go
@@ -16,11 +16,11 @@ type ScheduleType struct {
 	Name ScheduleTypeEnum
 }
 
-func NewScheduleType(name ScheduleTypeEnum, facility_id string) *ScheduleType {
-	return newScheduleType(ulid.NewULID(), name, facility_id)
+func NewScheduleType(name ScheduleTypeEnum) *ScheduleType {
+	return newScheduleType(ulid.NewULID(), name)
 }
 
-func newScheduleType(id string, name ScheduleTypeEnum, facility_id string) *ScheduleType {
+func newScheduleType(id string, name ScheduleTypeEnum) *ScheduleType {
 	return &ScheduleType{
 		ID:   id,
 		Name: name,

--- a/internal/domain/schedule/schedule_type/schedule_type_repository.go
+++ b/internal/domain/schedule/schedule_type/schedule_type_repository.go
@@ -1,6 +1,6 @@
 package schedule_type
 
 type ScheduleTypeRepository interface {
-	FindByFacilityID(facility_id string) ([]*ScheduleType, error)
+	FindAll(facility_id string) ([]*ScheduleType, error)
 	FindByID(id string) (*ScheduleType, error)
 }

--- a/internal/domain/schedule/schedule_type/schedule_type_repository.go
+++ b/internal/domain/schedule/schedule_type/schedule_type_repository.go
@@ -1,0 +1,6 @@
+package schedule_type
+
+type ScheduleTypeRepository interface {
+	FindByFacilityID(facility_id string) ([]*ScheduleType, error)
+	FindByID(id string) (*ScheduleType, error)
+}

--- a/internal/domain/schedule/schedule_type/schedule_type_repository.go
+++ b/internal/domain/schedule/schedule_type/schedule_type_repository.go
@@ -1,6 +1,8 @@
 package schedule_type
 
+import "context"
+
 type ScheduleTypeRepository interface {
-	FindAll(facility_id string) ([]*ScheduleType, error)
-	FindByID(id string) (*ScheduleType, error)
+	FindAll(ctx context.Context, facility_id string) ([]*ScheduleType, error)
+	FindByID(ctx context.Context, id string) (*ScheduleType, error)
 }

--- a/internal/domain/visit_info/route/route_repository.go
+++ b/internal/domain/visit_info/route/route_repository.go
@@ -1,8 +1,12 @@
 package route
 
-import "context"
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
 
 type RouteRepository interface {
 	FindByID(ctx context.Context, id string) (*Route, error)
-	Create(ctx context.Context, route *Route) error
+	Create(ctx context.Context, tx *gorm.DB, route *Route) error
 }

--- a/internal/domain/visit_info/route/route_service.go
+++ b/internal/domain/visit_info/route/route_service.go
@@ -1,0 +1,58 @@
+package route
+
+import (
+	addressDomain "api-buddy/domain/address"
+	"context"
+)
+
+type RouteService struct {
+	routeRepository   RouteRepository
+	addressRepository addressDomain.AddressRepository
+}
+
+func NewRouteService(
+	routeRepository RouteRepository,
+	addressRepository addressDomain.AddressRepository,
+) *RouteService {
+	return &RouteService{
+		routeRepository:   routeRepository,
+		addressRepository: addressRepository,
+	}
+}
+
+type RouteModel struct {
+	ID            string
+	TravelTime    int
+	FromAddressID string
+	DestinationID string
+}
+
+func (s *RouteService) CreateRoute(
+	ctx context.Context,
+	routeModel *RouteModel,
+) (*Route, error) {
+
+	// 住所の再構築または新規作成
+	fromAddress, err := s.addressRepository.FindByID(ctx, routeModel.FromAddressID)
+	if err != nil {
+		return nil, err
+	}
+
+	toAddress, err := s.addressRepository.FindByID(ctx, routeModel.DestinationID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 新規ルートの作成
+	route, err := NewRoute(routeModel.TravelTime, fromAddress, toAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.routeRepository.Create(ctx, route)
+	if err != nil {
+		return nil, err
+	}
+
+	return route, nil
+}

--- a/internal/domain/visit_info/route/route_service.go
+++ b/internal/domain/visit_info/route/route_service.go
@@ -3,6 +3,8 @@ package route
 import (
 	addressDomain "api-buddy/domain/address"
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type RouteService struct {
@@ -29,10 +31,10 @@ type RouteModel struct {
 
 func (s *RouteService) CreateRoute(
 	ctx context.Context,
+	tx *gorm.DB,
 	routeModel *RouteModel,
 ) (*Route, error) {
 
-	// 住所の再構築または新規作成
 	fromAddress, err := s.addressRepository.FindByID(ctx, routeModel.FromAddressID)
 	if err != nil {
 		return nil, err
@@ -49,7 +51,7 @@ func (s *RouteService) CreateRoute(
 		return nil, err
 	}
 
-	err = s.routeRepository.Create(ctx, route)
+	err = s.routeRepository.Create(ctx, tx, route)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/visit_info/visit_category/visit_category.go
+++ b/internal/domain/visit_info/visit_category/visit_category.go
@@ -6,20 +6,28 @@ import (
 	"github.com/Fukuemon/go-pkg/ulid"
 )
 
+type VisitCategoryType string
+
+const (
+	NightShift VisitCategoryType = "夜勤"
+	Emergency  VisitCategoryType = "緊急"
+	Hospital   VisitCategoryType = "入院"
+)
+
 type VisitCategory struct {
 	ID   string
-	Name string
+	Name VisitCategoryType
 	common.CommonModel
 }
 
-func NewVisitCategory(Name string) (*VisitCategory, error) {
+func NewVisitCategory(Name VisitCategoryType) (*VisitCategory, error) {
 	return newVisitCategory(
 		ulid.NewULID(),
 		Name,
 	)
 }
 
-func newVisitCategory(ID string, Name string) (*VisitCategory, error) {
+func newVisitCategory(ID string, Name VisitCategoryType) (*VisitCategory, error) {
 	visitCategory := &VisitCategory{
 		ID:   ID,
 		Name: Name,

--- a/internal/domain/visit_info/visit_category/visit_category.go
+++ b/internal/domain/visit_info/visit_category/visit_category.go
@@ -1,0 +1,31 @@
+package visit_category
+
+import (
+	"api-buddy/domain/common"
+
+	"github.com/Fukuemon/go-pkg/ulid"
+)
+
+type VisitCategory struct {
+	ID   string
+	Name string
+	common.CommonModel
+}
+
+func NewVisitCategory(Name string) (*VisitCategory, error) {
+	return newVisitCategory(
+		ulid.NewULID(),
+		Name,
+	)
+}
+
+func newVisitCategory(ID string, Name string) (*VisitCategory, error) {
+	visitCategory := &VisitCategory{
+		ID:   ID,
+		Name: Name,
+	}
+
+	common.InitializeCommonModel(&visitCategory.CommonModel)
+
+	return visitCategory, nil
+}

--- a/internal/domain/visit_info/visit_category/visit_category_repository.go
+++ b/internal/domain/visit_info/visit_category/visit_category_repository.go
@@ -3,7 +3,6 @@ package visit_category
 import "context"
 
 type VisitCategoryRepository interface {
-	Create(ctx context.Context, visitCategory *VisitCategory) error
 	FindAll(ctx context.Context) ([]*VisitCategory, error)
 	FindByID(ctx context.Context, id string) (*VisitCategory, error)
 }

--- a/internal/domain/visit_info/visit_category/visit_category_repository.go
+++ b/internal/domain/visit_info/visit_category/visit_category_repository.go
@@ -1,0 +1,9 @@
+package visit_category
+
+import "context"
+
+type VisitCategoryRepository interface {
+	Create(ctx context.Context, visitCategory *VisitCategory) error
+	FindAll(ctx context.Context) ([]*VisitCategory, error)
+	FindByID(ctx context.Context, id string) (*VisitCategory, error)
+}

--- a/internal/domain/visit_info/visit_info.go
+++ b/internal/domain/visit_info/visit_info.go
@@ -18,9 +18,9 @@ type VisitInfo struct {
 	Patient         *patientDomain.Patient `gorm:"foreignKey:PatientID"`
 	AssignedStaffID string
 	AssignedStaff   *userDomain.User `gorm:"foreignKey:AssignedStaffID"`
-	CompanionID     string
+	CompanionID     *string
 	Companion       *userDomain.User `gorm:"foreignKey:CompanionID"`
-	RouteID         string
+	RouteID         *string
 	Route           *routeDomain.Route `gorm:"foreignKey:RouteID"`
 	ServiceCodeID   string
 	ServiceCode     *serviceCodeDomain.ServiceCode       `gorm:"foreignKey:ServiceCodeID"`
@@ -35,7 +35,7 @@ type VisitInfoOption func(*VisitInfo)
 func WithCompanion(companion *userDomain.User) VisitInfoOption {
 	return func(vi *VisitInfo) {
 		if companion != nil {
-			vi.CompanionID = companion.ID
+			vi.CompanionID = &companion.ID
 			vi.Companion = companion
 		}
 	}
@@ -45,7 +45,7 @@ func WithCompanion(companion *userDomain.User) VisitInfoOption {
 func WithRoute(route *routeDomain.Route) VisitInfoOption {
 	return func(vi *VisitInfo) {
 		if route != nil {
-			vi.RouteID = route.ID
+			vi.RouteID = &route.ID
 			vi.Route = route
 		}
 	}
@@ -75,6 +75,11 @@ func NewVisitInfo(
 		AssignedStaff:   assignedStaff,
 		ServiceCodeID:   serviceCode.ID,
 		ServiceCode:     serviceCode,
+		RouteID:         nil,
+		Route:           nil,
+		CompanionID:     nil,
+		Companion:       nil,
+		VisitCategories: nil,
 	}
 
 	// Apply options

--- a/internal/domain/visit_info/visit_info.go
+++ b/internal/domain/visit_info/visit_info.go
@@ -12,13 +12,6 @@ import (
 	"github.com/Fukuemon/go-pkg/ulid"
 )
 
-type Option struct {
-	Companion       *userDomain.User
-	CompanionID     *string
-	VisitCategory   *visitCategoryDomain.VisitCategory
-	VisitCategoryID *string
-}
-
 type VisitInfo struct {
 	ID              string
 	PatientID       string
@@ -30,58 +23,63 @@ type VisitInfo struct {
 	RouteID         string
 	Route           *routeDomain.Route `gorm:"foreignKey:RouteID"`
 	ServiceCodeID   string
-	ServiceCode     *serviceCodeDomain.ServiceCode `gorm:"foreignKey:ServiceCodeID"`
-	VisitCategoryID string
-	VisitCategory   *visitCategoryDomain.VisitCategory `gorm:"foreignKey:VisitCategoryID"`
+	ServiceCode     *serviceCodeDomain.ServiceCode       `gorm:"foreignKey:ServiceCodeID"`
+	VisitCategories []*visitCategoryDomain.VisitCategory `gorm:"many2many:visit_info_visit_categories"`
 	common.CommonModel
 }
 
+// Functional option type
+type VisitInfoOption func(*VisitInfo)
+
+// WithCompanion sets the companion for the VisitInfo
+func WithCompanion(companion *userDomain.User) VisitInfoOption {
+	return func(vi *VisitInfo) {
+		if companion != nil {
+			vi.CompanionID = companion.ID
+			vi.Companion = companion
+		}
+	}
+}
+
+// WithRoute sets the route for the VisitInfo
+func WithRoute(route *routeDomain.Route) VisitInfoOption {
+	return func(vi *VisitInfo) {
+		if route != nil {
+			vi.RouteID = route.ID
+			vi.Route = route
+		}
+	}
+}
+
+// WithVisitCategories sets the visit categories for the VisitInfo
+func WithVisitCategories(categories []*visitCategoryDomain.VisitCategory) VisitInfoOption {
+	return func(vi *VisitInfo) {
+		if categories != nil {
+			vi.VisitCategories = categories
+		}
+	}
+}
+
+// NewVisitInfo initializes a new VisitInfo with required fields and options
 func NewVisitInfo(
 	patient *patientDomain.Patient,
 	assignedStaff *userDomain.User,
-	route *routeDomain.Route,
 	serviceCode *serviceCodeDomain.ServiceCode,
-	options *Option,
-) (*VisitInfo, error) {
-	return newVisitInfo(
-		ulid.NewULID(),
-		patient,
-		assignedStaff,
-		route,
-		serviceCode,
-		options,
-	)
-}
-
-func newVisitInfo(
-	ID string,
-	patient *patientDomain.Patient,
-	assignedStaff *userDomain.User,
-	route *routeDomain.Route,
-	serviceCode *serviceCodeDomain.ServiceCode,
-	options *Option,
+	options ...VisitInfoOption,
 ) (*VisitInfo, error) {
 	visitInfo := &VisitInfo{
-		ID:              ID,
+		ID:              ulid.NewULID(),
 		PatientID:       patient.ID,
 		Patient:         patient,
 		AssignedStaffID: assignedStaff.ID,
 		AssignedStaff:   assignedStaff,
-		RouteID:         route.ID,
-		Route:           route,
 		ServiceCodeID:   serviceCode.ID,
 		ServiceCode:     serviceCode,
 	}
 
-	if options != nil {
-		if options.Companion != nil {
-			visitInfo.CompanionID = options.Companion.ID
-			visitInfo.Companion = options.Companion
-		}
-		if options.VisitCategory != nil {
-			visitInfo.VisitCategoryID = options.VisitCategory.ID
-			visitInfo.VisitCategory = options.VisitCategory
-		}
+	// Apply options
+	for _, option := range options {
+		option(visitInfo)
 	}
 
 	common.InitializeCommonModel(&visitInfo.CommonModel)

--- a/internal/domain/visit_info/visit_info_repository.go
+++ b/internal/domain/visit_info/visit_info_repository.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/Fukuemon/go-pkg/query"
+	"gorm.io/gorm"
 )
 
 type VisitInfoRepository interface {
-	Create(ctx context.Context, visitInfo *VisitInfo) error
+	Create(ctx context.Context, tx *gorm.DB, visitInfo *VisitInfo) error
 	FindAll(ctx context.Context, filters []query.Filter, sort query.SortOption) ([]*VisitInfo, error)
 	FindByID(ctx context.Context, id string) (*VisitInfo, error)
 }

--- a/internal/domain/visit_info/visit_info_service.go
+++ b/internal/domain/visit_info/visit_info_service.go
@@ -14,7 +14,7 @@ type VisitInfoService struct {
 	patientRepository       patientDomain.PatientRepository
 	userRepository          userDomain.UserRepository
 	serviceCodeRepository   serviceCodeDomain.ServiceCodeRepository
-	routeService            routeDomain.RouteService
+	routeService            *routeDomain.RouteService
 	visitCategoryRepository visitCategoryDomain.VisitCategoryRepository
 }
 
@@ -23,7 +23,7 @@ func NewVisitInfoService(
 	patientRepository patientDomain.PatientRepository,
 	userRepository userDomain.UserRepository,
 	serviceCodeRepository serviceCodeDomain.ServiceCodeRepository,
-	routeService routeDomain.RouteService,
+	routeService *routeDomain.RouteService,
 	visitCategoryRepository visitCategoryDomain.VisitCategoryRepository,
 ) *VisitInfoService {
 	return &VisitInfoService{

--- a/internal/domain/visit_info/visit_info_service.go
+++ b/internal/domain/visit_info/visit_info_service.go
@@ -7,6 +7,8 @@ import (
 	serviceCodeDomain "api-buddy/domain/visit_info/service_code"
 	visitCategoryDomain "api-buddy/domain/visit_info/visit_category"
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type VisitInfoService struct {
@@ -45,10 +47,7 @@ type VisitInfoModel struct {
 	VisitCategoryIDs []*string
 }
 
-func (s *VisitInfoService) CreateVisitInfo(
-	ctx context.Context,
-	visitInfoModel VisitInfoModel,
-) (*VisitInfo, error) {
+func (s *VisitInfoService) CreateVisitInfo(ctx context.Context, tx *gorm.DB, visitInfoModel VisitInfoModel) (*VisitInfo, error) {
 	patient, err := s.patientRepository.FindByID(ctx, visitInfoModel.PatientID)
 	if err != nil {
 		return nil, err
@@ -70,7 +69,7 @@ func (s *VisitInfoService) CreateVisitInfo(
 	options := []VisitInfoOption{}
 	if visitInfoModel.Route != nil {
 		// ルートの作成
-		route, err := s.routeService.CreateRoute(ctx, visitInfoModel.Route)
+		route, err := s.routeService.CreateRoute(ctx, tx, visitInfoModel.Route)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +107,7 @@ func (s *VisitInfoService) CreateVisitInfo(
 	}
 
 	// 訪問情報の保存
-	if err := s.visitInfoRepository.Create(ctx, visitInfo); err != nil {
+	if err := s.visitInfoRepository.Create(ctx, tx, visitInfo); err != nil {
 		return nil, err
 	}
 

--- a/internal/domain/visit_info/visit_info_service.go
+++ b/internal/domain/visit_info/visit_info_service.go
@@ -1,0 +1,116 @@
+package visit_info
+
+import (
+	patientDomain "api-buddy/domain/patient"
+	userDomain "api-buddy/domain/user"
+	routeDomain "api-buddy/domain/visit_info/route"
+	serviceCodeDomain "api-buddy/domain/visit_info/service_code"
+	visitCategoryDomain "api-buddy/domain/visit_info/visit_category"
+	"context"
+)
+
+type VisitInfoService struct {
+	visitInfoRepository     VisitInfoRepository
+	patientRepository       patientDomain.PatientRepository
+	userRepository          userDomain.UserRepository
+	serviceCodeRepository   serviceCodeDomain.ServiceCodeRepository
+	routeService            routeDomain.RouteService
+	visitCategoryRepository visitCategoryDomain.VisitCategoryRepository
+}
+
+func NewVisitInfoService(
+	visitInfoRepository VisitInfoRepository,
+	patientRepository patientDomain.PatientRepository,
+	userRepository userDomain.UserRepository,
+	serviceCodeRepository serviceCodeDomain.ServiceCodeRepository,
+	routeService routeDomain.RouteService,
+	visitCategoryRepository visitCategoryDomain.VisitCategoryRepository,
+) *VisitInfoService {
+	return &VisitInfoService{
+		visitInfoRepository:     visitInfoRepository,
+		patientRepository:       patientRepository,
+		userRepository:          userRepository,
+		serviceCodeRepository:   serviceCodeRepository,
+		routeService:            routeService,
+		visitCategoryRepository: visitCategoryRepository,
+	}
+}
+
+type VisitInfoModel struct {
+	PatientID        string
+	AssignStaffID    string
+	CompanionID      *string
+	Route            *routeDomain.RouteModel
+	ServiceCodeID    string
+	VisitCategoryIDs []*string
+}
+
+func (s *VisitInfoService) CreateVisitInfo(
+	ctx context.Context,
+	visitInfoModel VisitInfoModel,
+) (*VisitInfo, error) {
+	patient, err := s.patientRepository.FindByID(ctx, visitInfoModel.PatientID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 担当スタッフの取得とバリデーション
+	assignStaff, err := s.userRepository.FindByID(ctx, visitInfoModel.AssignStaffID)
+	if err != nil {
+		return nil, err
+	}
+
+	// サービスコードの取得とバリデーション
+	serviceCode, err := s.serviceCodeRepository.FindByID(ctx, visitInfoModel.ServiceCodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// option処理
+	options := []VisitInfoOption{}
+	if visitInfoModel.Route != nil {
+		// ルートの作成
+		route, err := s.routeService.CreateRoute(ctx, visitInfoModel.Route)
+		if err != nil {
+			return nil, err
+		}
+
+		options = append(options, WithRoute(route))
+	}
+
+	// 訪問情報のオプションを作成
+	if visitInfoModel.CompanionID != nil {
+		companion, err := s.userRepository.FindByID(ctx, *visitInfoModel.CompanionID)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, WithCompanion(companion))
+	}
+
+	// 訪問カテゴリの取得
+	if visitInfoModel.VisitCategoryIDs != nil {
+		visitCategories := []*visitCategoryDomain.VisitCategory{}
+		for _, visitCategoryID := range visitInfoModel.VisitCategoryIDs {
+
+			visitCategory, err := s.visitCategoryRepository.FindByID(ctx, *visitCategoryID)
+			if err != nil {
+				return nil, err
+			}
+			visitCategories = append(visitCategories, visitCategory)
+		}
+		options = append(options, WithVisitCategories(visitCategories))
+	}
+
+	// 訪問情報の作成
+	visitInfo, err := NewVisitInfo(patient, assignStaff, serviceCode, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	// 訪問情報の保存
+	if err := s.visitInfoRepository.Create(ctx, visitInfo); err != nil {
+		return nil, err
+	}
+
+	return visitInfo, nil
+}

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.3
@@ -35,6 +36,7 @@ require (
 	github.com/bytedance/sonic/loader v0.2.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -58,6 +60,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.11.0 // indirect

--- a/internal/infrastructure/mysql/db/transaction.go
+++ b/internal/infrastructure/mysql/db/transaction.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// TransactionHandler はトランザクション内での処理を定義する関数
+type TransactionHandler func(tx *gorm.DB) error
+
+// WithTransaction はトランザクションを開始し、指定されたハンドラーを実行します。
+func WithTransaction(ctx context.Context, handler TransactionHandler) error {
+	db := GetDB()
+	tx := db.Begin() // トランザクション開始
+	if tx.Error != nil {
+		return tx.Error
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+			panic(r)
+		}
+	}()
+
+	// ハンドラーを実行
+	if err := handler(tx); err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	// コミット
+	if err := tx.Commit().Error; err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/infrastructure/mysql/db/transaction.go
+++ b/internal/infrastructure/mysql/db/transaction.go
@@ -6,13 +6,11 @@ import (
 	"gorm.io/gorm"
 )
 
-// TransactionHandler はトランザクション内での処理を定義する関数
 type TransactionHandler func(tx *gorm.DB) error
 
-// WithTransaction はトランザクションを開始し、指定されたハンドラーを実行します。
 func WithTransaction(ctx context.Context, handler TransactionHandler) error {
 	db := GetDB()
-	tx := db.Begin() // トランザクション開始
+	tx := db.Begin()
 	if tx.Error != nil {
 		return tx.Error
 	}

--- a/internal/infrastructure/mysql/repository/patient_repository.go
+++ b/internal/infrastructure/mysql/repository/patient_repository.go
@@ -74,7 +74,7 @@ func (r *PatientRepository) FindByFacilityID(ctx context.Context, facility_id st
 
 func (r *PatientRepository) FindByID(ctx context.Context, id string) (*patientDomain.Patient, error) {
 	var patient patientDomain.Patient
-	err := r.db.Preload("ServiceCode").Preload("Address").Preload("Area").Preload("Assigned_Staff").
+	err := r.db.Preload("ServiceCode").Preload("Address").Preload("Area").Preload("AssignedStaff").
 		Where("id = ?", id).
 		First(&patient).Error
 	if err != nil {

--- a/internal/infrastructure/mysql/repository/recurring_rule_repository.go
+++ b/internal/infrastructure/mysql/repository/recurring_rule_repository.go
@@ -1,0 +1,53 @@
+package repository
+
+import (
+	errorDomain "api-buddy/domain/error"
+	recurringRuleDomain "api-buddy/domain/schedule/recurring_rule"
+	"api-buddy/infrastructure/mysql/db"
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type RecurringRuleRepository struct {
+	db *gorm.DB
+}
+
+func NewRecurringRuleRepository() recurringRuleDomain.RecurringRuleRepository {
+	return &RecurringRuleRepository{
+		db: db.GetDB(),
+	}
+}
+
+func (r *RecurringRuleRepository) Create(ctx context.Context, recurringRule *recurringRuleDomain.RecurringRule) error {
+	err := r.db.Create(recurringRule).Error
+	if err != nil {
+		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+
+	return nil
+}
+
+func (r *RecurringRuleRepository) FindByFacilityID(ctx context.Context, facilityID string) ([]*recurringRuleDomain.RecurringRule, error) {
+	var recurringRules []*recurringRuleDomain.RecurringRule
+	err := r.db.Where("facility_id = ?", facilityID).Find(&recurringRules).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return recurringRules, nil
+}
+
+func (r *RecurringRuleRepository) FindByID(ctx context.Context, id string) (*recurringRuleDomain.RecurringRule, error) {
+	var recurringRule *recurringRuleDomain.RecurringRule
+	err := r.db.Where("id = ?", id).First(&recurringRule).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return recurringRule, nil
+}

--- a/internal/infrastructure/mysql/repository/recurring_rule_repository.go
+++ b/internal/infrastructure/mysql/repository/recurring_rule_repository.go
@@ -19,12 +19,15 @@ func NewRecurringRuleRepository() recurringRuleDomain.RecurringRuleRepository {
 	}
 }
 
-func (r *RecurringRuleRepository) Create(ctx context.Context, recurringRule *recurringRuleDomain.RecurringRule) error {
-	err := r.db.Create(recurringRule).Error
+func (r *RecurringRuleRepository) Create(ctx context.Context, tx *gorm.DB, recurringRule *recurringRuleDomain.RecurringRule) error {
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+	err := db.Create(recurringRule).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}
-
 	return nil
 }
 

--- a/internal/infrastructure/mysql/repository/recurring_schedule_repository.go
+++ b/internal/infrastructure/mysql/repository/recurring_schedule_repository.go
@@ -1,0 +1,87 @@
+package repository
+
+import (
+	"api-buddy/domain/common"
+	errorDomain "api-buddy/domain/error"
+	recurringScheduleDomain "api-buddy/domain/schedule/recurring_schedule"
+	"api-buddy/infrastructure/mysql/db"
+	"context"
+
+	"github.com/Fukuemon/go-pkg/query"
+	"gorm.io/gorm"
+)
+
+type RecurringScheduleRepository struct {
+	db *gorm.DB
+}
+
+func NewRecurringScheduleRepository() recurringScheduleDomain.RecurringScheduleRepository {
+	return &RecurringScheduleRepository{
+		db: db.GetDB(),
+	}
+}
+
+func (r *RecurringScheduleRepository) Create(ctx context.Context, recurringSchedule *recurringScheduleDomain.RecurringSchedule) error {
+	err := r.db.Create(recurringSchedule).Error
+	if err != nil {
+		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+
+	return nil
+}
+
+func (r *RecurringScheduleRepository) FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*recurringScheduleDomain.RecurringSchedule, error) {
+	q := query.NewQuery()
+
+	// Queryオブジェクトにフィルターを適用
+	for _, filter := range filters {
+		filter.Apply(q)
+	}
+
+	dbQuery := r.db
+
+	for _, mapping := range recurringScheduleDomain.RecurringScheduleRelationMappings {
+		if value, exists := q.Filters[mapping.FilterField]; exists {
+			dbQuery = dbQuery.Joins("JOIN "+mapping.TableName+" ON "+mapping.JoinKey).
+				Where(mapping.FilterField+" = ?", value)
+		}
+	}
+
+	for key, value := range q.Filters {
+		if _, isRelationField := recurringScheduleDomain.RecurringScheduleRelationMappings[key]; !isRelationField {
+			dbQuery = dbQuery.Where(key, value)
+		}
+	}
+
+	if sort.Field != "" {
+		if mapping, exists := recurringScheduleDomain.RecurringScheduleRelationMappings[sort.Field]; exists {
+			dbQuery = dbQuery.Joins("JOIN " + mapping.TableName + " ON " + mapping.JoinKey).
+				Order(mapping.FilterField + " " + sort.Order)
+		} else {
+			dbQuery = dbQuery.Order(sort.Field + " " + sort.Order)
+		}
+	} else {
+		dbQuery = dbQuery.Order(common.UpdatedAt + " " + query.DESC)
+	}
+
+	var recurringSchedules []*recurringScheduleDomain.RecurringSchedule
+	err := dbQuery.Preload("Facility").Preload("RecurringRule").Preload("VisitInfo").Preload("ScheduleType").Preload("Staff").
+		Where("facility_id = ?", facility_id).Find(&recurringSchedules).Error
+	if err != nil {
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return recurringSchedules, nil
+}
+
+func (r *RecurringScheduleRepository) FindByID(ctx context.Context, id string) (*recurringScheduleDomain.RecurringSchedule, error) {
+	var recurringSchedule *recurringScheduleDomain.RecurringSchedule
+	err := r.db.Preload("Facility").Preload("RecurringRule").Preload("VisitInfo").Preload("ScheduleType").Preload("Staff").
+		Where("id = ?", id).First(&recurringSchedule).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return recurringSchedule, nil
+}

--- a/internal/infrastructure/mysql/repository/recurring_schedule_repository.go
+++ b/internal/infrastructure/mysql/repository/recurring_schedule_repository.go
@@ -21,12 +21,15 @@ func NewRecurringScheduleRepository() recurringScheduleDomain.RecurringScheduleR
 	}
 }
 
-func (r *RecurringScheduleRepository) Create(ctx context.Context, recurringSchedule *recurringScheduleDomain.RecurringSchedule) error {
-	err := r.db.Create(recurringSchedule).Error
+func (r *RecurringScheduleRepository) Create(ctx context.Context, tx *gorm.DB, recurringSchedule *recurringScheduleDomain.RecurringSchedule) error {
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+	err := db.Create(recurringSchedule).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}
-
 	return nil
 }
 

--- a/internal/infrastructure/mysql/repository/route_repository.go
+++ b/internal/infrastructure/mysql/repository/route_repository.go
@@ -19,8 +19,12 @@ func NewRouteRepository() routeDomain.RouteRepository {
 	}
 }
 
-func (r *RouteRepository) Create(ctx context.Context, route *routeDomain.Route) error {
-	err := r.db.Create(route).Error
+func (r *RouteRepository) Create(ctx context.Context, tx *gorm.DB, route *routeDomain.Route) error {
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+	err := db.Create(route).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}

--- a/internal/infrastructure/mysql/repository/schedule_cancel_repository.go
+++ b/internal/infrastructure/mysql/repository/schedule_cancel_repository.go
@@ -1,0 +1,40 @@
+package repository
+
+import (
+	errorDomain "api-buddy/domain/error"
+	scheduleCancelDomain "api-buddy/domain/schedule/schedule_cancel"
+	"api-buddy/infrastructure/mysql/db"
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type ScheduleCancelRepository struct {
+	db *gorm.DB
+}
+
+func NewScheduleCancelRepository() scheduleCancelDomain.ScheduleCancelRepository {
+	return &ScheduleCancelRepository{
+		db: db.GetDB(),
+	}
+}
+
+func (r *ScheduleCancelRepository) Create(ctx context.Context, scheduleCancel *scheduleCancelDomain.ScheduleCancel) error {
+	err := r.db.Create(scheduleCancel).Error
+	if err != nil {
+		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return nil
+}
+
+func (r *ScheduleCancelRepository) FindByID(ctx context.Context, id string) (*scheduleCancelDomain.ScheduleCancel, error) {
+	var scheduleCancel *scheduleCancelDomain.ScheduleCancel
+	err := r.db.Where("id = ?", id).First(&scheduleCancel).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return scheduleCancel, nil
+}

--- a/internal/infrastructure/mysql/repository/schedule_repository.go
+++ b/internal/infrastructure/mysql/repository/schedule_repository.go
@@ -1,0 +1,92 @@
+package repository
+
+import (
+	errorDomain "api-buddy/domain/error"
+	scheduleDomain "api-buddy/domain/schedule"
+	"api-buddy/infrastructure/mysql/db"
+	"context"
+
+	"github.com/Fukuemon/go-pkg/query"
+	"gorm.io/gorm"
+)
+
+type ScheduleRepository struct {
+	db *gorm.DB
+}
+
+func NewScheduleRepository() scheduleDomain.ScheduleRepository {
+	return &ScheduleRepository{
+		db: db.GetDB(),
+	}
+}
+
+func (r *ScheduleRepository) Create(ctx context.Context, schedule *scheduleDomain.Schedule) error {
+	err := r.db.Create(schedule).Error
+	if err != nil {
+		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return nil
+}
+
+func (r *ScheduleRepository) FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*scheduleDomain.Schedule, error) {
+	// Queryオブジェクトを初期化
+	q := query.NewQuery()
+
+	// Queryオブジェクトにフィルターを適用
+	for _, filter := range filters {
+		filter.Apply(q)
+	}
+
+	dbQuery := r.db
+
+	// リレーションテーブルに基づいたフィルタリングのQueryを適用
+	for _, mapping := range scheduleDomain.ScheduleRelationMappings {
+		if value, exists := q.Filters[mapping.FilterField]; exists {
+			dbQuery = dbQuery.Joins("JOIN "+mapping.TableName+" ON "+mapping.JoinKey).
+				Where(mapping.FilterField+" = ?", value)
+		}
+	}
+
+	// 残りのフィルタリング（`schedules` テーブルに対するフィルター）を適用
+	for key, value := range q.Filters {
+		if _, isRelationField := scheduleDomain.ScheduleRelationMappings[key]; !isRelationField {
+			dbQuery = dbQuery.Where(key, value)
+		}
+	}
+
+	// ソートオプションの適用
+	if sort.Field != "" {
+		if mapping, exists := scheduleDomain.ScheduleRelationMappings[sort.Field]; exists {
+			dbQuery = dbQuery.Joins("JOIN " + mapping.TableName + " ON " + mapping.JoinKey).
+				Order(mapping.TableName + "." + sort.Field + " " + sort.Order)
+		} else {
+			dbQuery = dbQuery.Order(sort.Field + " " + sort.Order)
+		}
+	} else {
+		dbQuery = dbQuery.Order(sort.Field + " " + sort.Order)
+	}
+
+	var schedules []*scheduleDomain.Schedule
+	err := dbQuery.Preload("Facility").Preload("RecurringSchedule").Preload("VisitInfo").Preload("ScheduleType").Preload("Staff").Preload("ScheduleCancel").
+		Find(&schedules).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return schedules, nil
+}
+
+func (r *ScheduleRepository) FindByID(ctx context.Context, id string) (*scheduleDomain.Schedule, error) {
+	var schedule *scheduleDomain.Schedule
+	err := r.db.Preload("Facility").Preload("RecurringSchedule").Preload("VisitInfo").Preload("ScheduleType").Preload("Staff").Preload("ScheduleCancel").
+		Where("id = ?", id).First(&schedule).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return schedule, nil
+}

--- a/internal/infrastructure/mysql/repository/schedule_repository.go
+++ b/internal/infrastructure/mysql/repository/schedule_repository.go
@@ -20,8 +20,14 @@ func NewScheduleRepository() scheduleDomain.ScheduleRepository {
 	}
 }
 
-func (r *ScheduleRepository) Create(ctx context.Context, schedule *scheduleDomain.Schedule) error {
-	err := r.db.Create(schedule).Error
+func (r *ScheduleRepository) Create(ctx context.Context, tx *gorm.DB, schedule *scheduleDomain.Schedule) error {
+	// トランザクションが渡されていない場合、通常のDB接続を使用
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+
+	err := db.Create(schedule).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}

--- a/internal/infrastructure/mysql/repository/schedule_type_repository.go
+++ b/internal/infrastructure/mysql/repository/schedule_type_repository.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	errorDomain "api-buddy/domain/error"
+	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
+	"api-buddy/infrastructure/mysql/db"
+
+	"gorm.io/gorm"
+)
+
+type ScheduleTypeRepository struct {
+	db *gorm.DB
+}
+
+func NewScheduleTypeRepository() scheduleTypeDomain.ScheduleTypeRepository {
+	return &ScheduleTypeRepository{
+		db: db.GetDB(),
+	}
+}
+
+func (r *ScheduleTypeRepository) FindAll(facility_id string) ([]*scheduleTypeDomain.ScheduleType, error) {
+	var scheduleTypes []*scheduleTypeDomain.ScheduleType
+	err := r.db.Find(&scheduleTypes).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return scheduleTypes, nil
+}
+
+func (r *ScheduleTypeRepository) FindByID(id string) (*scheduleTypeDomain.ScheduleType, error) {
+	var scheduleType scheduleTypeDomain.ScheduleType
+	err := r.db.Where("id = ?", id).First(&scheduleType).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return &scheduleType, nil
+}

--- a/internal/infrastructure/mysql/repository/schedule_type_repository.go
+++ b/internal/infrastructure/mysql/repository/schedule_type_repository.go
@@ -4,6 +4,7 @@ import (
 	errorDomain "api-buddy/domain/error"
 	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
 	"api-buddy/infrastructure/mysql/db"
+	"context"
 
 	"gorm.io/gorm"
 )
@@ -18,7 +19,7 @@ func NewScheduleTypeRepository() scheduleTypeDomain.ScheduleTypeRepository {
 	}
 }
 
-func (r *ScheduleTypeRepository) FindAll(facility_id string) ([]*scheduleTypeDomain.ScheduleType, error) {
+func (r *ScheduleTypeRepository) FindAll(ctx context.Context, facility_id string) ([]*scheduleTypeDomain.ScheduleType, error) {
 	var scheduleTypes []*scheduleTypeDomain.ScheduleType
 	err := r.db.Find(&scheduleTypes).Error
 	if err != nil {
@@ -30,7 +31,7 @@ func (r *ScheduleTypeRepository) FindAll(facility_id string) ([]*scheduleTypeDom
 	return scheduleTypes, nil
 }
 
-func (r *ScheduleTypeRepository) FindByID(id string) (*scheduleTypeDomain.ScheduleType, error) {
+func (r *ScheduleTypeRepository) FindByID(ctx context.Context, id string) (*scheduleTypeDomain.ScheduleType, error) {
 	var scheduleType scheduleTypeDomain.ScheduleType
 	err := r.db.Where("id = ?", id).First(&scheduleType).Error
 	if err != nil {

--- a/internal/infrastructure/mysql/repository/visit_category_repository.go
+++ b/internal/infrastructure/mysql/repository/visit_category_repository.go
@@ -1,0 +1,44 @@
+package repository
+
+import (
+	errorDomain "api-buddy/domain/error"
+	visitCategoryDomain "api-buddy/domain/visit_info/visit_category"
+	"api-buddy/infrastructure/mysql/db"
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type VisitCategoryRepository struct {
+	db *gorm.DB
+}
+
+func NewVisitCategoryRepository() visitCategoryDomain.VisitCategoryRepository {
+	return &VisitCategoryRepository{
+		db: db.GetDB(),
+	}
+}
+
+func (r *VisitCategoryRepository) FindAll(ctx context.Context) ([]*visitCategoryDomain.VisitCategory, error) {
+	var visitCategories []*visitCategoryDomain.VisitCategory
+	err := r.db.Find(&visitCategories).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return visitCategories, nil
+}
+
+func (r *VisitCategoryRepository) FindByID(ctx context.Context, id string) (*visitCategoryDomain.VisitCategory, error) {
+	var visitCategory visitCategoryDomain.VisitCategory
+	err := r.db.Where("id = ?", id).First(&visitCategory).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
+	}
+	return &visitCategory, nil
+}

--- a/internal/infrastructure/mysql/repository/visit_info_repository.go
+++ b/internal/infrastructure/mysql/repository/visit_info_repository.go
@@ -63,7 +63,8 @@ func (r *VisitInfoRepository) FindAll(ctx context.Context, filters []query.Filte
 	}
 
 	var visitInfos []*visitInfoDomain.VisitInfo
-	err := dbQuery.Preload("Patient").Preload("User").Preload("Route").Find(&visitInfos).Error
+	err := dbQuery.Preload("Patient").Preload("AssignedStaff").Preload("Route").Preload("VisitCategory").Preload("ServiceCode").
+		Find(&visitInfos).Error
 	if err != nil {
 		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}
@@ -72,7 +73,8 @@ func (r *VisitInfoRepository) FindAll(ctx context.Context, filters []query.Filte
 
 func (r *VisitInfoRepository) FindByID(ctx context.Context, id string) (*visitInfoDomain.VisitInfo, error) {
 	var visitInfo visitInfoDomain.VisitInfo
-	err := r.db.Preload("Patient").Preload("User").Preload("Route").Where("id = ?", id).First(&visitInfo).Error
+	err := r.db.Preload("Patient").Preload("AssignedStaff").Preload("Route").Preload("VisitCategory").Preload("ServiceCode").
+		Where("id = ?", id).First(&visitInfo).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, errorDomain.WrapError(errorDomain.NotFoundErr, err)

--- a/internal/infrastructure/mysql/repository/visit_info_repository.go
+++ b/internal/infrastructure/mysql/repository/visit_info_repository.go
@@ -21,8 +21,13 @@ func NewVisitInfoRepository() visitInfoDomain.VisitInfoRepository {
 	}
 }
 
-func (r *VisitInfoRepository) Create(ctx context.Context, visitInfo *visitInfoDomain.VisitInfo) error {
-	err := r.db.Create(visitInfo).Error
+func (r *VisitInfoRepository) Create(ctx context.Context, tx *gorm.DB, visitInfo *visitInfoDomain.VisitInfo) error {
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+
+	err := db.Create(visitInfo).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}

--- a/internal/infrastructure/mysql/repository/visit_info_repository.go
+++ b/internal/infrastructure/mysql/repository/visit_info_repository.go
@@ -63,7 +63,7 @@ func (r *VisitInfoRepository) FindAll(ctx context.Context, filters []query.Filte
 	}
 
 	var visitInfos []*visitInfoDomain.VisitInfo
-	err := dbQuery.Preload("Patient").Preload("AssignedStaff").Preload("Route").Preload("VisitCategory").Preload("ServiceCode").
+	err := dbQuery.Preload("Patient").Preload("AssignedStaff").Preload("Route").Preload("VisitCategories").Preload("ServiceCode").
 		Find(&visitInfos).Error
 	if err != nil {
 		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
@@ -73,7 +73,7 @@ func (r *VisitInfoRepository) FindAll(ctx context.Context, filters []query.Filte
 
 func (r *VisitInfoRepository) FindByID(ctx context.Context, id string) (*visitInfoDomain.VisitInfo, error) {
 	var visitInfo visitInfoDomain.VisitInfo
-	err := r.db.Preload("Patient").Preload("AssignedStaff").Preload("Route").Preload("VisitCategory").Preload("ServiceCode").
+	err := r.db.Preload("Patient").Preload("AssignedStaff").Preload("Route").Preload("VisitCategories").Preload("ServiceCode").
 		Where("id = ?", id).First(&visitInfo).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {

--- a/internal/presentation/schedule/handler.go
+++ b/internal/presentation/schedule/handler.go
@@ -175,11 +175,32 @@ func (h *handler) CreateRecurringSchedule(ctx *gin.Context) {
 		return
 	}
 
+	var visitInfo *visitInfoDomain.VisitInfoModel
+	if params.VisitInfo != nil {
+		visitInfo = &visitInfoDomain.VisitInfoModel{
+			PatientID:     params.VisitInfo.PatientID,
+			AssignStaffID: params.VisitInfo.AssignStaffID,
+			CompanionID:   params.VisitInfo.CompanionID,
+			Route: func() *routeDomain.RouteModel {
+				if params.VisitInfo.Route != nil {
+					return &routeDomain.RouteModel{
+						TravelTime:    params.VisitInfo.Route.TravelTime,
+						FromAddressID: params.VisitInfo.Route.FromAddressID,
+						DestinationID: params.VisitInfo.Route.DestinationID,
+					}
+				}
+				return nil
+			}(),
+			ServiceCodeID:    params.VisitInfo.ServiceCodeID,
+			VisitCategoryIDs: params.VisitInfo.VisitCategoryIDs,
+		}
+	}
+
 	input := recurringSchedule.CreateRecurringScheduleUseCaseInputDto{
 		ScheduleTypeID: params.ScheduleTypeID,
 		RecurringRule: recurringSchedule.RecurringRuleModel{
 			Frequency:   params.RecurringRuleModel.Frequency,
-			DaysOfWeek:  params.RecurringRuleModel.DaysOfWeek,
+			DayOfWeek:   params.RecurringRuleModel.DayOfWeek,
 			DayOfMonth:  params.RecurringRuleModel.DayOfMonth,
 			WeekOfMonth: params.RecurringRuleModel.WeekOfMonth,
 			StartDate:   params.RecurringRuleModel.StartDate,
@@ -192,18 +213,7 @@ func (h *handler) CreateRecurringSchedule(ctx *gin.Context) {
 		FacilityID:  facilityID,
 		Title:       params.Title,
 		Description: params.Description,
-		VisitInfo: &visitInfoDomain.VisitInfoModel{
-			PatientID:     params.VisitInfo.PatientID,
-			AssignStaffID: params.VisitInfo.AssignStaffID,
-			CompanionID:   params.VisitInfo.CompanionID,
-			Route: &routeDomain.RouteModel{
-				TravelTime:    params.VisitInfo.Route.TravelTime,
-				FromAddressID: params.VisitInfo.Route.FromAddressID,
-				DestinationID: params.VisitInfo.Route.DestinationID,
-			},
-			ServiceCodeID:    params.VisitInfo.ServiceCodeID,
-			VisitCategoryIDs: params.VisitInfo.VisitCategoryIDs,
-		},
+		VisitInfo:   visitInfo,
 	}
 
 	output, err := h.createRecurringScheduleUseCase.Run(ctx, input)
@@ -219,39 +229,52 @@ func (h *handler) CreateRecurringSchedule(ctx *gin.Context) {
 		StartTime:      output.StartTime,
 		EndTime:        output.EndTime,
 		StaffID:        output.StaffID,
-		VisitInfo: &VisitInfoResponseModel{
-			ID:                output.VisitInfo.ID,
-			PatientName:       output.VisitInfo.Patient.Name,
-			AssignedStaffName: output.VisitInfo.AssignedStaff.Username,
-			CompanionName:     output.VisitInfo.Companion.Username,
-			Route: &RouteResponseModel{
-				TravelTime:    output.VisitInfo.Route.TravelTime,
-				AddressID:     output.VisitInfo.Route.AddressID,
-				DestinationID: output.VisitInfo.Route.DestinationID,
-			},
-			ServiceCode: output.VisitInfo.ServiceCode.Code,
-			VisitCategories: func() []VisitCategoryResponseModel {
-				var categories []VisitCategoryResponseModel
-				for _, category := range output.VisitInfo.VisitCategories {
-					categories = append(categories, VisitCategoryResponseModel{
-						ID:   category.ID,
-						Name: category.Name,
-					})
-				}
-				return categories
-			}(),
-		},
+		VisitInfo: func() *VisitInfoResponseModel {
+			if output.VisitInfo == nil {
+				return nil
+			}
+			return &VisitInfoResponseModel{
+				ID:                output.VisitInfo.ID,
+				PatientName:       output.VisitInfo.Patient.Name,
+				AssignedStaffName: output.VisitInfo.AssignedStaff.Username,
+				CompanionName:     output.VisitInfo.Companion.Username,
+				Route: func() *RouteResponseModel {
+					if output.VisitInfo.Route != nil {
+						return &RouteResponseModel{
+							TravelTime:    output.VisitInfo.Route.TravelTime,
+							AddressID:     output.VisitInfo.Route.AddressID,
+							DestinationID: output.VisitInfo.Route.DestinationID,
+						}
+					}
+					return nil
+				}(),
+				ServiceCode: output.VisitInfo.ServiceCode.Code,
+				VisitCategories: func() []VisitCategoryResponseModel {
+					var categories []VisitCategoryResponseModel
+					if output.VisitInfo.VisitCategories != nil {
+						for _, category := range output.VisitInfo.VisitCategories {
+							categories = append(categories, VisitCategoryResponseModel{
+								ID:   category.ID,
+								Name: category.Name,
+							})
+						}
+					}
+					return categories
+				}(),
+			}
+		}(),
 		Title:       output.Title,
 		Description: output.Description,
 		RecurringRule: &RecurringRuleResponseModel{
 			Frequency:   output.RecurringRule.Frequency,
-			DaysOfWeek:  output.RecurringRule.DaysOfWeek,
+			DaysOfWeek:  output.RecurringRule.DayOfWeek,
 			DayOfMonth:  output.RecurringRule.DayOfMonth,
 			WeekOfMonth: output.RecurringRule.WeekOfMonth,
 			StartDate:   output.RecurringRule.StartDate,
 			EndDate:     output.RecurringRule.EndDate,
 		},
 	}
+
 	settings.ReturnStatusCreated(ctx, response)
 }
 

--- a/internal/presentation/schedule/handler.go
+++ b/internal/presentation/schedule/handler.go
@@ -4,6 +4,7 @@ import (
 	errorDomain "api-buddy/domain/error"
 	visitInfoDomain "api-buddy/domain/visit_info"
 	routeDomain "api-buddy/domain/visit_info/route"
+	_ "api-buddy/presentation/common"
 	"api-buddy/presentation/settings"
 	"api-buddy/usecase/schedule"
 	recurringSchedule "api-buddy/usecase/schedule/recurring_schedule"
@@ -75,13 +76,47 @@ func (h *handler) CreateSchedule(ctx *gin.Context) {
 		},
 	}
 
-	schedule, err := h.createScheduleUseCase.Run(ctx, input)
+	output, err := h.createScheduleUseCase.Run(ctx, input)
+
 	if err != nil {
 		ctx.Error(err)
 		return
 	}
 
-	settings.ReturnStatusCreated(ctx, schedule)
+	response := CreateScheduleResponse{
+		ID:             output.ID,
+		ScheduleTypeID: output.ScheduleTypeID,
+		Date:           output.Date,
+		StartTime:      output.StartTime,
+		EndTime:        output.EndTime,
+		StaffID:        output.StaffID,
+		VisitInfo: &VisitInfoResponseModel{
+			ID:              output.VisitInfo.ID,
+			PatientID:       output.VisitInfo.PatientID,
+			AssignedStaffID: output.VisitInfo.AssignedStaffID,
+			CompanionID:     output.VisitInfo.CompanionID,
+			Route: &RouteResponseModel{
+				TravelTime:    output.VisitInfo.Route.TravelTime,
+				AddressID:     output.VisitInfo.Route.AddressID,
+				DestinationID: output.VisitInfo.Route.DestinationID,
+			},
+			ServiceCodeID: output.VisitInfo.ServiceCodeID,
+			VisitCategories: func() []VisitCategoryResponseModel {
+				var categories []VisitCategoryResponseModel
+				for _, category := range output.VisitInfo.VisitCategories {
+					categories = append(categories, VisitCategoryResponseModel{
+						ID:   category.ID,
+						Name: category.Name,
+					})
+				}
+				return categories
+			}(),
+		},
+		Title:       output.Title,
+		Description: output.Description,
+	}
+
+	settings.ReturnStatusCreated(ctx, response)
 
 }
 
@@ -141,13 +176,53 @@ func (h *handler) CreateRecurringSchedule(ctx *gin.Context) {
 		},
 	}
 
-	schedule, err := h.createRecurringScheduleUseCase.Run(ctx, input)
+	output, err := h.createRecurringScheduleUseCase.Run(ctx, input)
 	if err != nil {
 		ctx.Error(err)
 		return
 	}
 
-	settings.ReturnStatusCreated(ctx, schedule)
+	response := CreateRecurringScheduleResponse{
+		ID:             output.ID,
+		ScheduleTypeID: output.ScheduleTypeID,
+		Date:           output.Date,
+		StartTime:      output.StartTime,
+		EndTime:        output.EndTime,
+		StaffID:        output.StaffID,
+		VisitInfo: &VisitInfoResponseModel{
+			ID:              output.VisitInfo.ID,
+			PatientID:       output.VisitInfo.PatientID,
+			AssignedStaffID: output.VisitInfo.AssignedStaffID,
+			CompanionID:     output.VisitInfo.CompanionID,
+			Route: &RouteResponseModel{
+				TravelTime:    output.VisitInfo.Route.TravelTime,
+				AddressID:     output.VisitInfo.Route.AddressID,
+				DestinationID: output.VisitInfo.Route.DestinationID,
+			},
+			ServiceCodeID: output.VisitInfo.ServiceCodeID,
+			VisitCategories: func() []VisitCategoryResponseModel {
+				var categories []VisitCategoryResponseModel
+				for _, category := range output.VisitInfo.VisitCategories {
+					categories = append(categories, VisitCategoryResponseModel{
+						ID:   category.ID,
+						Name: category.Name,
+					})
+				}
+				return categories
+			}(),
+		},
+		Title:       output.Title,
+		Description: output.Description,
+		RecurringRule: &RecurringRuleResponseModel{
+			Frequency:   output.RecurringRule.Frequency,
+			DaysOfWeek:  output.RecurringRule.DaysOfWeek,
+			DayOfMonth:  output.RecurringRule.DayOfMonth,
+			WeekOfMonth: output.RecurringRule.WeekOfMonth,
+			StartDate:   output.RecurringRule.StartDate,
+			EndDate:     output.RecurringRule.EndDate,
+		},
+	}
+	settings.ReturnStatusCreated(ctx, response)
 }
 
 // GetSchedule godoc

--- a/internal/presentation/schedule/handler.go
+++ b/internal/presentation/schedule/handler.go
@@ -53,27 +53,38 @@ func (h *handler) CreateSchedule(ctx *gin.Context) {
 		return
 	}
 
-	input := schedule.CreateUseCaseInputDto{
-		ScheduleTypeID: params.ScheduleTypeID,
-		Date:           params.Date,
-		StartTime:      params.StartTime,
-		EndTime:        params.EndTime,
-		StaffID:        params.StaffID,
-		FacilityID:     facilityID,
-		Title:          params.Title,
-		Description:    params.Description,
-		VisitInfo: &visitInfoDomain.VisitInfoModel{
+	var visitInfo *visitInfoDomain.VisitInfoModel
+	if params.VisitInfo != nil {
+		visitInfo = &visitInfoDomain.VisitInfoModel{
 			PatientID:     params.VisitInfo.PatientID,
 			AssignStaffID: params.VisitInfo.AssignStaffID,
 			CompanionID:   params.VisitInfo.CompanionID,
-			Route: &routeDomain.RouteModel{
-				TravelTime:    params.VisitInfo.Route.TravelTime,
-				FromAddressID: params.VisitInfo.Route.FromAddressID,
-				DestinationID: params.VisitInfo.Route.DestinationID,
-			},
+			Route: func() *routeDomain.RouteModel {
+				if params.VisitInfo.Route != nil {
+					return &routeDomain.RouteModel{
+						TravelTime:    params.VisitInfo.Route.TravelTime,
+						FromAddressID: params.VisitInfo.Route.FromAddressID,
+						DestinationID: params.VisitInfo.Route.DestinationID,
+					}
+				}
+				return nil
+			}(),
 			ServiceCodeID:    params.VisitInfo.ServiceCodeID,
 			VisitCategoryIDs: params.VisitInfo.VisitCategoryIDs,
-		},
+		}
+	}
+
+	input := schedule.CreateUseCaseInputDto{
+		ScheduleTypeID:      params.ScheduleTypeID,
+		Date:                params.Date,
+		StartTime:           params.StartTime,
+		EndTime:             params.EndTime,
+		StaffID:             params.StaffID,
+		FacilityID:          facilityID,
+		Title:               params.Title,
+		Description:         params.Description,
+		VisitInfo:           visitInfo,
+		RecurringScheduleID: params.RecurringScheduleID,
 	}
 
 	output, err := h.createScheduleUseCase.Run(ctx, input)
@@ -84,36 +95,55 @@ func (h *handler) CreateSchedule(ctx *gin.Context) {
 	}
 
 	response := CreateScheduleResponse{
-		ID:             output.ID,
-		ScheduleTypeID: output.ScheduleTypeID,
-		Date:           output.Date,
-		StartTime:      output.StartTime,
-		EndTime:        output.EndTime,
-		StaffID:        output.StaffID,
-		VisitInfo: &VisitInfoResponseModel{
-			ID:              output.VisitInfo.ID,
-			PatientID:       output.VisitInfo.PatientID,
-			AssignedStaffID: output.VisitInfo.AssignedStaffID,
-			CompanionID:     output.VisitInfo.CompanionID,
-			Route: &RouteResponseModel{
-				TravelTime:    output.VisitInfo.Route.TravelTime,
-				AddressID:     output.VisitInfo.Route.AddressID,
-				DestinationID: output.VisitInfo.Route.DestinationID,
-			},
-			ServiceCodeID: output.VisitInfo.ServiceCodeID,
-			VisitCategories: func() []VisitCategoryResponseModel {
-				var categories []VisitCategoryResponseModel
-				for _, category := range output.VisitInfo.VisitCategories {
-					categories = append(categories, VisitCategoryResponseModel{
-						ID:   category.ID,
-						Name: category.Name,
-					})
-				}
-				return categories
-			}(),
-		},
+		ID:           output.ID,
+		ScheduleType: string(output.ScheduleType.Name),
+		Date:         output.Date,
+		StartTime:    output.StartTime,
+		EndTime:      output.EndTime,
+		StaffName:    output.Staff.Username,
+		VisitInfo: func() *VisitInfoResponseModel {
+			if output.VisitInfo == nil {
+				return nil
+			}
+			return &VisitInfoResponseModel{
+				ID:                output.VisitInfo.ID,
+				PatientName:       output.VisitInfo.Patient.Name,
+				AssignedStaffName: output.VisitInfo.AssignedStaff.Username,
+				CompanionName:     output.VisitInfo.Companion.Username,
+				Route: func() *RouteResponseModel {
+					if output.VisitInfo.Route != nil {
+						return &RouteResponseModel{
+							TravelTime:    output.VisitInfo.Route.TravelTime,
+							AddressID:     output.VisitInfo.Route.AddressID,
+							DestinationID: output.VisitInfo.Route.DestinationID,
+						}
+					}
+					return nil
+				}(),
+				ServiceCode: output.VisitInfo.ServiceCode.Code,
+				VisitCategories: func() []VisitCategoryResponseModel {
+					var categories []VisitCategoryResponseModel
+					if output.VisitInfo.VisitCategories != nil {
+						for _, category := range output.VisitInfo.VisitCategories {
+							categories = append(categories, VisitCategoryResponseModel{
+								ID:   category.ID,
+								Name: category.Name,
+							})
+						}
+					}
+					return categories
+				}(),
+			}
+		}(),
 		Title:       output.Title,
 		Description: output.Description,
+		RecurringScheduleID: func() string {
+			if output.RecurringScheduleID == nil {
+				return ""
+			} else {
+				return *output.RecurringScheduleID
+			}
+		}(),
 	}
 
 	settings.ReturnStatusCreated(ctx, response)
@@ -190,16 +220,16 @@ func (h *handler) CreateRecurringSchedule(ctx *gin.Context) {
 		EndTime:        output.EndTime,
 		StaffID:        output.StaffID,
 		VisitInfo: &VisitInfoResponseModel{
-			ID:              output.VisitInfo.ID,
-			PatientID:       output.VisitInfo.PatientID,
-			AssignedStaffID: output.VisitInfo.AssignedStaffID,
-			CompanionID:     output.VisitInfo.CompanionID,
+			ID:                output.VisitInfo.ID,
+			PatientName:       output.VisitInfo.Patient.Name,
+			AssignedStaffName: output.VisitInfo.AssignedStaff.Username,
+			CompanionName:     output.VisitInfo.Companion.Username,
 			Route: &RouteResponseModel{
 				TravelTime:    output.VisitInfo.Route.TravelTime,
 				AddressID:     output.VisitInfo.Route.AddressID,
 				DestinationID: output.VisitInfo.Route.DestinationID,
 			},
-			ServiceCodeID: output.VisitInfo.ServiceCodeID,
+			ServiceCode: output.VisitInfo.ServiceCode.Code,
 			VisitCategories: func() []VisitCategoryResponseModel {
 				var categories []VisitCategoryResponseModel
 				for _, category := range output.VisitInfo.VisitCategories {

--- a/internal/presentation/schedule/handler.go
+++ b/internal/presentation/schedule/handler.go
@@ -1,0 +1,170 @@
+package schedule
+
+import (
+	errorDomain "api-buddy/domain/error"
+	visitInfoDomain "api-buddy/domain/visit_info"
+	routeDomain "api-buddy/domain/visit_info/route"
+	"api-buddy/presentation/settings"
+	"api-buddy/usecase/schedule"
+	recurringSchedule "api-buddy/usecase/schedule/recurring_schedule"
+
+	"github.com/Fukuemon/go-pkg/validator"
+	"github.com/gin-gonic/gin"
+)
+
+type handler struct {
+	createScheduleUseCase          *schedule.CreateScheduleUseCase
+	createRecurringScheduleUseCase *recurringSchedule.CreateRecurringScheduleUseCase
+}
+
+func NewHandler(
+	createScheduleUseCase *schedule.CreateScheduleUseCase,
+	createRecurringScheduleUseCase *recurringSchedule.CreateRecurringScheduleUseCase,
+) *handler {
+	return &handler{
+		createScheduleUseCase:          createScheduleUseCase,
+		createRecurringScheduleUseCase: createRecurringScheduleUseCase,
+	}
+}
+
+// CreateSchedule godoc
+// @Summary 予定を作成する
+// @Tags Schedule
+// @Accept json
+// @Produce json
+// @Param request body CreateScheduleRequest true "予定作成リクエスト"
+// @Param facility_id path string true "施設ID"
+// @Success 201 {object} CreateScheduleResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /facilities/{facility_id}/schedules [post]
+func (h *handler) CreateSchedule(ctx *gin.Context) {
+	facilityID := ctx.Param("facility_id")
+	var params CreateScheduleRequest
+	if err := ctx.ShouldBindJSON(&params); err != nil {
+		ctx.Error(errorDomain.ValidationError(err))
+		return
+	}
+
+	if err := validator.StructValidation(params); err != nil {
+		ctx.Error(errorDomain.ValidationError(err))
+		return
+	}
+
+	input := schedule.CreateUseCaseInputDto{
+		ScheduleTypeID: params.ScheduleTypeID,
+		Date:           params.Date,
+		StartTime:      params.StartTime,
+		EndTime:        params.EndTime,
+		StaffID:        params.StaffID,
+		FacilityID:     facilityID,
+		Title:          params.Title,
+		Description:    params.Description,
+		VisitInfo: &visitInfoDomain.VisitInfoModel{
+			PatientID:     params.VisitInfo.PatientID,
+			AssignStaffID: params.VisitInfo.AssignStaffID,
+			CompanionID:   params.VisitInfo.CompanionID,
+			Route: &routeDomain.RouteModel{
+				TravelTime:    params.VisitInfo.Route.TravelTime,
+				FromAddressID: params.VisitInfo.Route.FromAddressID,
+				DestinationID: params.VisitInfo.Route.DestinationID,
+			},
+			ServiceCodeID:    params.VisitInfo.ServiceCodeID,
+			VisitCategoryIDs: params.VisitInfo.VisitCategoryIDs,
+		},
+	}
+
+	schedule, err := h.createScheduleUseCase.Run(ctx, input)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	settings.ReturnStatusCreated(ctx, schedule)
+
+}
+
+// CreateRecurringSchedule godoc
+// @Summary 繰り返し予定を作成する
+// @Tags Schedule
+// @Accept json
+// @Produce json
+// @Param request body CreateRecurringScheduleRequest true "予定作成リクエスト"
+// @Param facility_id path string true "施設ID"
+// @Success 201 {object} CreateRecurringScheduleResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /facilities/{facility_id}/schedules/recurring [post]
+func (h *handler) CreateRecurringSchedule(ctx *gin.Context) {
+	facilityID := ctx.Param("facility_id")
+	var params CreateRecurringScheduleRequest
+	if err := ctx.ShouldBindJSON(&params); err != nil {
+		ctx.Error(errorDomain.ValidationError(err))
+		return
+	}
+
+	if err := validator.StructValidation(params); err != nil {
+		ctx.Error(errorDomain.ValidationError(err))
+		return
+	}
+
+	input := recurringSchedule.CreateRecurringScheduleUseCaseInputDto{
+		ScheduleTypeID: params.ScheduleTypeID,
+		RecurringRule: recurringSchedule.RecurringRuleModel{
+			Frequency:   params.RecurringRuleModel.Frequency,
+			DaysOfWeek:  params.RecurringRuleModel.DaysOfWeek,
+			DayOfMonth:  params.RecurringRuleModel.DayOfMonth,
+			WeekOfMonth: params.RecurringRuleModel.WeekOfMonth,
+			StartDate:   params.RecurringRuleModel.StartDate,
+			EndDate:     params.RecurringRuleModel.EndDate,
+		},
+		Date:        params.Date,
+		StartTime:   params.StartTime,
+		EndTime:     params.EndTime,
+		StaffID:     params.StaffID,
+		FacilityID:  facilityID,
+		Title:       params.Title,
+		Description: params.Description,
+		VisitInfo: &visitInfoDomain.VisitInfoModel{
+			PatientID:     params.VisitInfo.PatientID,
+			AssignStaffID: params.VisitInfo.AssignStaffID,
+			CompanionID:   params.VisitInfo.CompanionID,
+			Route: &routeDomain.RouteModel{
+				TravelTime:    params.VisitInfo.Route.TravelTime,
+				FromAddressID: params.VisitInfo.Route.FromAddressID,
+				DestinationID: params.VisitInfo.Route.DestinationID,
+			},
+			ServiceCodeID:    params.VisitInfo.ServiceCodeID,
+			VisitCategoryIDs: params.VisitInfo.VisitCategoryIDs,
+		},
+	}
+
+	schedule, err := h.createRecurringScheduleUseCase.Run(ctx, input)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	settings.ReturnStatusCreated(ctx, schedule)
+}
+
+// GetSchedule godoc
+// @Summary 予定を取得する
+// @Tags Schedule
+// @Accept json
+
+// CreateChangeRecurringSchedule godoc
+// @Summary 繰り返し予定を変更する
+// @Tags Schedule
+// @Accept json
+// @Produce json
+// @Param request body CreateChangeRecurringScheduleRequest true "予定作成リクエスト"
+// @Param facility_id path string true "施設ID"
+// @Param recurring_schedule_id path string true "繰り返し予定ID"
+// @Success 201 {object} CreateChangeRecurringScheduleResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /facilities/{facility_id}/schedules/{recurring_schedule_id} [put]

--- a/internal/presentation/schedule/request.go
+++ b/internal/presentation/schedule/request.go
@@ -6,14 +6,15 @@ import (
 )
 
 type CreateScheduleRequest struct {
-	ScheduleTypeID string                 `json:"schedule_type_id" validate:"required,ulid"`
-	Date           common.Date            `json:"date" validate:"required" swaggertype:"string" format:"date"`
-	StartTime      common.Time            `json:"start_time" validate:"required"`
-	EndTime        common.Time            `json:"end_time" validate:"required"`
-	StaffID        string                 `json:"staff_id" validate:"required,ulid"`
-	VisitInfo      *VisitInfoRequestModel `json:"visit_info" validate:"omitempty"`
-	Title          *string                `json:"title" validate:"omitempty"`
-	Description    *string                `json:"description" validate:"omitempty"`
+	ScheduleTypeID      string                 `json:"schedule_type_id" validate:"required,ulid"`
+	Date                common.Date            `json:"date" validate:"required" swaggertype:"string" format:"date"`
+	StartTime           common.Time            `json:"start_time" validate:"required"`
+	EndTime             common.Time            `json:"end_time" validate:"required"`
+	StaffID             string                 `json:"staff_id" validate:"required,ulid"`
+	VisitInfo           *VisitInfoRequestModel `json:"visit_info" validate:"omitempty"`
+	Title               *string                `json:"title" validate:"omitempty"`
+	Description         *string                `json:"description" validate:"omitempty"`
+	RecurringScheduleID *string                `json:"recurring_schedule_id" validate:"omitempty,ulid"`
 }
 
 type CreateRecurringScheduleRequest struct {

--- a/internal/presentation/schedule/request.go
+++ b/internal/presentation/schedule/request.go
@@ -7,7 +7,7 @@ import (
 
 type CreateScheduleRequest struct {
 	ScheduleTypeID string                 `json:"schedule_type_id" validate:"required,ulid"`
-	Date           common.Date            `json:"date" validate:"required"`
+	Date           common.Date            `json:"date" validate:"required" swaggertype:"string" format:"date"`
 	StartTime      common.Time            `json:"start_time" validate:"required"`
 	EndTime        common.Time            `json:"end_time" validate:"required"`
 	StaffID        string                 `json:"staff_id" validate:"required,ulid"`
@@ -18,7 +18,7 @@ type CreateScheduleRequest struct {
 
 type CreateRecurringScheduleRequest struct {
 	ScheduleTypeID     string                     `json:"schedule_type_id" validate:"required,ulid"`
-	Date               common.Date                `json:"date" validate:"required"`
+	Date               common.Date                `json:"date" validate:"required" swaggertype:"string" format:"date"`
 	StartTime          common.Time                `json:"start_time" validate:"required"`
 	EndTime            common.Time                `json:"end_time" validate:"required"`
 	StaffID            string                     `json:"staff_id" validate:"required,ulid"`
@@ -30,7 +30,7 @@ type CreateRecurringScheduleRequest struct {
 
 type CreateChangeRecurringScheduleRequest struct {
 	ScheduleTypeID          string                 `json:"schedule_type_id" validate:"required,ulid"`
-	Date                    common.Date            `json:"date" validate:"required"`
+	Date                    common.Date            `json:"date" validate:"required" swaggertype:"string" format:"date"`
 	StartTime               common.Time            `json:"start_time" validate:"required"`
 	EndTime                 common.Time            `json:"end_time" validate:"required"`
 	StaffID                 string                 `json:"staff_id" validate:"required,ulid"`
@@ -38,7 +38,7 @@ type CreateChangeRecurringScheduleRequest struct {
 	Title                   *string                `json:"title" validate:"omitempty"`
 	Description             *string                `json:"description" validate:"omitempty"`
 	RecurringScheduleID     *string                `json:"recurring_schedule_id" validate:"recurring,ulid"`
-	BeforeChangeDate        common.Date            `json:"before_change_date" validate:"required"`
+	BeforeChangeDate        common.Date            `json:"before_change_date" validate:"required" swaggertype:"string" format:"date"`
 	BeforeChangeStartTime   common.Time            `json:"before_change_start_time" validate:"required"`
 	RecurringExclusionDates []int                  `json:"recurring_exclusion_dates" validate:"omitempty"`
 }
@@ -63,6 +63,6 @@ type RecurringRuleRequestModel struct {
 	DaysOfWeek  *int                                  `json:"days_of_week" validate:"omitempty"`
 	DayOfMonth  *int                                  `json:"day_of_month" validate:"omitempty"`
 	WeekOfMonth *int                                  `json:"week_of_month" validate:"omitempty"`
-	StartDate   common.Date                           `json:"start_date" validate:"required"`
-	EndDate     *common.Date                          `json:"end_date" validate:"omitempty"`
+	StartDate   common.Date                           `json:"start_date" validate:"required" swaggertype:"string" format:"date"`
+	EndDate     *common.Date                          `json:"end_date" validate:"omitempty" swaggertype:"string" format:"date"`
 }

--- a/internal/presentation/schedule/request.go
+++ b/internal/presentation/schedule/request.go
@@ -1,0 +1,68 @@
+package schedule
+
+import (
+	"api-buddy/domain/common"
+	recurringScheduleDomain "api-buddy/domain/schedule/recurring_rule"
+)
+
+type CreateScheduleRequest struct {
+	ScheduleTypeID string                 `json:"schedule_type_id" validate:"required,ulid"`
+	Date           common.Date            `json:"date" validate:"required"`
+	StartTime      common.Time            `json:"start_time" validate:"required"`
+	EndTime        common.Time            `json:"end_time" validate:"required"`
+	StaffID        string                 `json:"staff_id" validate:"required,ulid"`
+	VisitInfo      *VisitInfoRequestModel `json:"visit_info" validate:"omitempty"`
+	Title          *string                `json:"title" validate:"omitempty"`
+	Description    *string                `json:"description" validate:"omitempty"`
+}
+
+type CreateRecurringScheduleRequest struct {
+	ScheduleTypeID     string                     `json:"schedule_type_id" validate:"required,ulid"`
+	Date               common.Date                `json:"date" validate:"required"`
+	StartTime          common.Time                `json:"start_time" validate:"required"`
+	EndTime            common.Time                `json:"end_time" validate:"required"`
+	StaffID            string                     `json:"staff_id" validate:"required,ulid"`
+	VisitInfo          *VisitInfoRequestModel     `json:"visit_info" validate:"omitempty"`
+	Title              *string                    `json:"title" validate:"omitempty"`
+	Description        *string                    `json:"description" validate:"omitempty"`
+	RecurringRuleModel *RecurringRuleRequestModel `json:"recurring_rule" validate:"omitempty"`
+}
+
+type CreateChangeRecurringScheduleRequest struct {
+	ScheduleTypeID          string                 `json:"schedule_type_id" validate:"required,ulid"`
+	Date                    common.Date            `json:"date" validate:"required"`
+	StartTime               common.Time            `json:"start_time" validate:"required"`
+	EndTime                 common.Time            `json:"end_time" validate:"required"`
+	StaffID                 string                 `json:"staff_id" validate:"required,ulid"`
+	VisitInfo               *VisitInfoRequestModel `json:"visit_info" validate:"omitempty"`
+	Title                   *string                `json:"title" validate:"omitempty"`
+	Description             *string                `json:"description" validate:"omitempty"`
+	RecurringScheduleID     *string                `json:"recurring_schedule_id" validate:"recurring,ulid"`
+	BeforeChangeDate        common.Date            `json:"before_change_date" validate:"required"`
+	BeforeChangeStartTime   common.Time            `json:"before_change_start_time" validate:"required"`
+	RecurringExclusionDates []int                  `json:"recurring_exclusion_dates" validate:"omitempty"`
+}
+
+type VisitInfoRequestModel struct {
+	PatientID        string             `json:"patient_id" validate:"required,ulid"`
+	AssignStaffID    string             `json:"assign_staff_id" validate:"required,ulid"`
+	CompanionID      *string            `json:"companion_id" validate:"omitempty,ulid"`
+	Route            *RouteRequestModel `json:"route" validate:"omitempty"`
+	ServiceCodeID    string             `json:"service_code_id" validate:"required,ulid"`
+	VisitCategoryIDs []*string          `json:"visit_category_ids" validate:"omitempty,dive,ulid"`
+}
+
+type RouteRequestModel struct {
+	TravelTime    int    `json:"travel_time" validate:"omitempty"`
+	FromAddressID string `json:"from_address_id" validate:"required,ulid"`
+	DestinationID string `json:"destination_id" validate:"required,ulid"`
+}
+
+type RecurringRuleRequestModel struct {
+	Frequency   recurringScheduleDomain.FrequencyEnum `json:"frequency" validate:"required"`
+	DaysOfWeek  *int                                  `json:"days_of_week" validate:"omitempty"`
+	DayOfMonth  *int                                  `json:"day_of_month" validate:"omitempty"`
+	WeekOfMonth *int                                  `json:"week_of_month" validate:"omitempty"`
+	StartDate   common.Date                           `json:"start_date" validate:"required"`
+	EndDate     *common.Date                          `json:"end_date" validate:"omitempty"`
+}

--- a/internal/presentation/schedule/request.go
+++ b/internal/presentation/schedule/request.go
@@ -61,7 +61,7 @@ type RouteRequestModel struct {
 
 type RecurringRuleRequestModel struct {
 	Frequency   recurringScheduleDomain.FrequencyEnum `json:"frequency" validate:"required"`
-	DaysOfWeek  *int                                  `json:"days_of_week" validate:"omitempty"`
+	DayOfWeek   *int                                  `json:"day_of_week" validate:"omitempty"`
 	DayOfMonth  *int                                  `json:"day_of_month" validate:"omitempty"`
 	WeekOfMonth *int                                  `json:"week_of_month" validate:"omitempty"`
 	StartDate   common.Date                           `json:"start_date" validate:"required" swaggertype:"string" format:"date"`

--- a/internal/presentation/schedule/response.go
+++ b/internal/presentation/schedule/response.go
@@ -1,0 +1,1 @@
+package schedule

--- a/internal/presentation/schedule/response.go
+++ b/internal/presentation/schedule/response.go
@@ -1,1 +1,62 @@
 package schedule
+
+import (
+	"api-buddy/domain/common"
+	recurringRuleDomain "api-buddy/domain/schedule/recurring_rule"
+	visitCategoryDomain "api-buddy/domain/visit_info/visit_category"
+)
+
+type CreateScheduleResponse struct {
+	ID             string                  `json:"id"`
+	ScheduleTypeID string                  `json:"schedule_type_id"`
+	Date           common.Date             `json:"date"`
+	StartTime      common.Time             `json:"start_time"`
+	EndTime        common.Time             `json:"end_time"`
+	StaffID        string                  `json:"staff_id"`
+	VisitInfo      *VisitInfoResponseModel `json:"visit_info"`
+	Title          string                  `json:"title"`
+	Description    string                  `json:"description"`
+}
+
+type VisitInfoResponseModel struct {
+	ID              string                       `json:"id"`
+	PatientID       string                       `json:"patient_id"`
+	AssignedStaffID string                       `json:"assigned_staff_id"`
+	CompanionID     string                       `json:"companion_id"`
+	Route           *RouteResponseModel          `json:"route"`
+	ServiceCodeID   string                       `json:"service_code_id"`
+	VisitCategories []VisitCategoryResponseModel `json:"visit_categories"`
+}
+
+type VisitCategoryResponseModel struct {
+	ID   string                                `json:"id"`
+	Name visitCategoryDomain.VisitCategoryType `json:"name"`
+}
+
+type RouteResponseModel struct {
+	TravelTime    int    `json:"travel_time"`
+	AddressID     string `json:"address_id"`
+	DestinationID string `json:"destination_id"`
+}
+
+type CreateRecurringScheduleResponse struct {
+	ID             string                      `json:"id"`
+	ScheduleTypeID string                      `json:"schedule_type_id"`
+	Date           common.Date                 `json:"date"`
+	StartTime      common.Time                 `json:"start_time"`
+	EndTime        common.Time                 `json:"end_time"`
+	StaffID        string                      `json:"staff_id"`
+	VisitInfo      *VisitInfoResponseModel     `json:"visit_info"`
+	Title          string                      `json:"title"`
+	Description    string                      `json:"description"`
+	RecurringRule  *RecurringRuleResponseModel `json:"recurring_rule"`
+}
+
+type RecurringRuleResponseModel struct {
+	Frequency   recurringRuleDomain.FrequencyEnum `json:"frequency"`
+	DaysOfWeek  int                               `json:"days_of_week"`
+	DayOfMonth  int                               `json:"day_of_month"`
+	WeekOfMonth int                               `json:"week_of_month"`
+	StartDate   common.Date                       `json:"start_date"`
+	EndDate     common.Date                       `json:"end_date"`
+}

--- a/internal/presentation/schedule/response.go
+++ b/internal/presentation/schedule/response.go
@@ -7,25 +7,26 @@ import (
 )
 
 type CreateScheduleResponse struct {
-	ID             string                  `json:"id"`
-	ScheduleTypeID string                  `json:"schedule_type_id"`
-	Date           common.Date             `json:"date"`
-	StartTime      common.Time             `json:"start_time"`
-	EndTime        common.Time             `json:"end_time"`
-	StaffID        string                  `json:"staff_id"`
-	VisitInfo      *VisitInfoResponseModel `json:"visit_info"`
-	Title          string                  `json:"title"`
-	Description    string                  `json:"description"`
+	ID                  string                  `json:"id"`
+	ScheduleType        string                  `json:"schedule_type"`
+	Date                common.Date             `json:"date"`
+	StartTime           common.Time             `json:"start_time"`
+	EndTime             common.Time             `json:"end_time"`
+	StaffName           string                  `json:"staff_name"`
+	VisitInfo           *VisitInfoResponseModel `json:"visit_info"`
+	Title               string                  `json:"title"`
+	Description         string                  `json:"description"`
+	RecurringScheduleID string                  `json:"recurring_schedule_id"`
 }
 
 type VisitInfoResponseModel struct {
-	ID              string                       `json:"id"`
-	PatientID       string                       `json:"patient_id"`
-	AssignedStaffID string                       `json:"assigned_staff_id"`
-	CompanionID     string                       `json:"companion_id"`
-	Route           *RouteResponseModel          `json:"route"`
-	ServiceCodeID   string                       `json:"service_code_id"`
-	VisitCategories []VisitCategoryResponseModel `json:"visit_categories"`
+	ID                string                       `json:"id"`
+	PatientName       string                       `json:"patient_name"`
+	AssignedStaffName string                       `json:"assigned_staff_name"`
+	CompanionName     string                       `json:"companion_name"`
+	Route             *RouteResponseModel          `json:"route"`
+	ServiceCode       string                       `json:"service_code"`
+	VisitCategories   []VisitCategoryResponseModel `json:"visit_categories"`
 }
 
 type VisitCategoryResponseModel struct {

--- a/internal/presentation/schedule/schedule_type/handler.go
+++ b/internal/presentation/schedule/schedule_type/handler.go
@@ -1,0 +1,56 @@
+package schedule_type
+
+import (
+	errorDomain "api-buddy/domain/error"
+	_ "api-buddy/presentation/common"
+	"api-buddy/presentation/settings"
+	scheduleTypeUse "api-buddy/usecase/schedule/schedule_type"
+
+	pathValidator "github.com/Fukuemon/go-pkg/validator/gin"
+
+	"github.com/gin-gonic/gin"
+)
+
+type handler struct {
+	fetchScheduleTypesUseCase *scheduleTypeUse.FetchScheduleTypesUseCase
+}
+
+func NewHandler(fetchScheduleTypesUseCase *scheduleTypeUse.FetchScheduleTypesUseCase) *handler {
+	return &handler{
+		fetchScheduleTypesUseCase: fetchScheduleTypesUseCase,
+	}
+}
+
+// FetchScheduleTypes godoc
+// @Summary 予定種別一覧を取得する
+// @Tags ScheduleType
+// @Accept json
+// @Produce json
+// @Success 200 {object} ScheduleTypeListResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /facilities/{facility_id}/schedules/schedule_types [get]
+func (h *handler) FetchScheduleTypes(ctx *gin.Context) {
+	facilityId := pathValidator.Param(ctx, "facility_id", "required", "ulid")
+
+	err := facilityId.ParamValidate()
+	if err != nil {
+		ctx.Error(errorDomain.ValidationError(err))
+		return
+	}
+	output, err := h.fetchScheduleTypesUseCase.Run(ctx, facilityId.ParamValue)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	response := make(ScheduleTypeListResponse, 0, len(output))
+	for _, o := range output {
+		response = append(response, ScheduleTypeResponse{
+			ID:   o.ID,
+			Name: o.Name,
+		})
+	}
+	settings.ReturnStatusOK(ctx, response)
+}

--- a/internal/presentation/schedule/schedule_type/response.go
+++ b/internal/presentation/schedule/schedule_type/response.go
@@ -1,0 +1,10 @@
+package schedule_type
+
+import "api-buddy/domain/schedule/schedule_type"
+
+type ScheduleTypeResponse struct {
+	ID   string                         `json:"id"`
+	Name schedule_type.ScheduleTypeEnum `json:"name"`
+}
+
+type ScheduleTypeListResponse []ScheduleTypeResponse

--- a/internal/presentation/visit_info/service_code/handler.go
+++ b/internal/presentation/visit_info/service_code/handler.go
@@ -1,0 +1,49 @@
+package service_code
+
+import (
+	_ "api-buddy/presentation/common"
+	"api-buddy/presentation/settings"
+	serviceCodeUse "api-buddy/usecase/visit_info/service_code"
+
+	"github.com/gin-gonic/gin"
+)
+
+type handler struct {
+	fetchServiceCodesUseCase *serviceCodeUse.FetchServiceCodesUseCase
+}
+
+func NewHandler(fetchServiceCodesUseCase *serviceCodeUse.FetchServiceCodesUseCase) *handler {
+	return &handler{
+		fetchServiceCodesUseCase: fetchServiceCodesUseCase,
+	}
+}
+
+// FetchServiceCodes godoc
+// @Summary サービスコード一覧を取得する
+// @Tags ServiceCode
+// @Accept json
+// @Produce json
+// @Success 200 {object} ServiceCodeListResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /visit_infos/service_codes [get]
+func (h *handler) FetchServiceCodes(ctx *gin.Context) {
+	output, err := h.fetchServiceCodesUseCase.Run(ctx)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	response := make(ServiceCodeListResponse, 0, len(output))
+	for _, o := range output {
+		response = append(response, ServiceCodeResponse{
+			ID:                    o.ID,
+			Code:                  o.Code,
+			ServiceTimeRangeStart: o.ServiceTimeRangeStart,
+			ServiceTimeRangeEnd:   o.ServiceTimeRangeEnd,
+		})
+	}
+
+	settings.ReturnStatusOK(ctx, response)
+}

--- a/internal/presentation/visit_info/service_code/response.go
+++ b/internal/presentation/visit_info/service_code/response.go
@@ -1,0 +1,10 @@
+package service_code
+
+type ServiceCodeResponse struct {
+	ID                    string `json:"id"`
+	Code                  string `json:"code"`
+	ServiceTimeRangeStart int    `json:"service_time_range_start"`
+	ServiceTimeRangeEnd   int    `json:"service_time_range_end"`
+}
+
+type ServiceCodeListResponse []ServiceCodeResponse

--- a/internal/presentation/visit_info/visit_category/handler.go
+++ b/internal/presentation/visit_info/visit_category/handler.go
@@ -1,0 +1,46 @@
+package visit_category
+
+import (
+	_ "api-buddy/presentation/common"
+	"api-buddy/presentation/settings"
+	visitCategoryUse "api-buddy/usecase/visit_info/visit_category"
+
+	"github.com/gin-gonic/gin"
+)
+
+type handler struct {
+	fetchVisitCategoriesUseCase *visitCategoryUse.FetchVisitCategoriesUseCase
+}
+
+func NewHandler(fetchVisitCategoriesUseCase *visitCategoryUse.FetchVisitCategoriesUseCase) *handler {
+	return &handler{
+		fetchVisitCategoriesUseCase: fetchVisitCategoriesUseCase,
+	}
+}
+
+// FetchVisitCategories godoc
+// @Summary 訪問カテゴリ一覧を取得する
+// @Tags VisitCategory
+// @Accept json
+// @Produce json
+// @Success 200 {object} VisitCategoryListResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /visit_infos/visit_categories [get]
+func (h *handler) FetchVisitCategories(ctx *gin.Context) {
+	output, err := h.fetchVisitCategoriesUseCase.Run(ctx)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	response := make(VisitCategoryListResponse, 0, len(output))
+	for _, o := range output {
+		response = append(response, VisitCategoryResponse{
+			ID:   o.ID,
+			Name: o.Name,
+		})
+	}
+	settings.ReturnStatusOK(ctx, response)
+}

--- a/internal/presentation/visit_info/visit_category/response.go
+++ b/internal/presentation/visit_info/visit_category/response.go
@@ -1,0 +1,10 @@
+package visit_category
+
+import "api-buddy/domain/visit_info/visit_category"
+
+type VisitCategoryResponse struct {
+	ID   string                           `json:"id"`
+	Name visit_category.VisitCategoryType `json:"name"`
+}
+
+type VisitCategoryListResponse []VisitCategoryResponse

--- a/internal/server/route/route.go
+++ b/internal/server/route/route.go
@@ -11,8 +11,11 @@ import (
 	"api-buddy/presentation/health_handler"
 	policyPre "api-buddy/presentation/policy"
 	schedulePre "api-buddy/presentation/schedule"
+	scheduleTypePre "api-buddy/presentation/schedule/schedule_type"
 	"api-buddy/presentation/settings"
 	userPre "api-buddy/presentation/user"
+	serviceCodePre "api-buddy/presentation/visit_info/service_code"
+	visitCategoryPre "api-buddy/presentation/visit_info/visit_category"
 	addressUse "api-buddy/usecase/address"
 	areaUse "api-buddy/usecase/facility/area"
 	departmentUse "api-buddy/usecase/facility/department"
@@ -21,7 +24,10 @@ import (
 	policyUse "api-buddy/usecase/policy"
 	scheduleUse "api-buddy/usecase/schedule"
 	recurringScheduleUse "api-buddy/usecase/schedule/recurring_schedule"
+	scheduleTypeUse "api-buddy/usecase/schedule/schedule_type"
 	userUse "api-buddy/usecase/user"
+	serviceCodeUse "api-buddy/usecase/visit_info/service_code"
+	visitCategoryUse "api-buddy/usecase/visit_info/visit_category"
 
 	visitInfoDomain "api-buddy/domain/visit_info"
 	routeDomain "api-buddy/domain/visit_info/route"
@@ -48,6 +54,9 @@ func InitRoute(api *gin.Engine) {
 		addressRoute(v1)
 		areaRoute(v1)
 		scheduleRoute(v1)
+		scheduleTypeRoute(v1)
+		serviceCodeRoute(v1)
+		visitCategoryRoute(v1)
 	}
 
 	// Swagger
@@ -203,4 +212,31 @@ func scheduleRoute(r *gin.RouterGroup) {
 
 	group = r.Group("/facilities/:facility_id/schedules/recurring")
 	group.POST("", h.CreateRecurringSchedule)
+}
+
+func scheduleTypeRoute(r *gin.RouterGroup) {
+	scheduleTypeRepository := repository.NewScheduleTypeRepository()
+	h := scheduleTypePre.NewHandler(
+		scheduleTypeUse.NewFetchScheduleTypesUseCase(scheduleTypeRepository),
+	)
+	group := r.Group("/facilities/:facility_id/schedules/schedule_types")
+	group.GET("", h.FetchScheduleTypes)
+}
+
+func serviceCodeRoute(r *gin.RouterGroup) {
+	serviceCodeRepository := repository.NewServiceCodeRepository()
+	h := serviceCodePre.NewHandler(
+		serviceCodeUse.NewFetchServiceCodesUseCase(serviceCodeRepository),
+	)
+	group := r.Group("/visit_infos/service_codes")
+	group.GET("", h.FetchServiceCodes)
+}
+
+func visitCategoryRoute(r *gin.RouterGroup) {
+	visitCategoryRepository := repository.NewVisitCategoryRepository()
+	h := visitCategoryPre.NewHandler(
+		visitCategoryUse.NewFetchVisitCategoriesUseCase(visitCategoryRepository),
+	)
+	group := r.Group("/visit_infos/visit_categories")
+	group.GET("", h.FetchVisitCategories)
 }

--- a/internal/server/route/route.go
+++ b/internal/server/route/route.go
@@ -10,6 +10,7 @@ import (
 	teamPre "api-buddy/presentation/facility/team"
 	"api-buddy/presentation/health_handler"
 	policyPre "api-buddy/presentation/policy"
+	schedulePre "api-buddy/presentation/schedule"
 	"api-buddy/presentation/settings"
 	userPre "api-buddy/presentation/user"
 	addressUse "api-buddy/usecase/address"
@@ -18,7 +19,12 @@ import (
 	positionUse "api-buddy/usecase/facility/position"
 	teamUse "api-buddy/usecase/facility/team"
 	policyUse "api-buddy/usecase/policy"
+	scheduleUse "api-buddy/usecase/schedule"
+	recurringScheduleUse "api-buddy/usecase/schedule/recurring_schedule"
 	userUse "api-buddy/usecase/user"
+
+	visitInfoDomain "api-buddy/domain/visit_info"
+	routeDomain "api-buddy/domain/visit_info/route"
 
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
@@ -41,6 +47,7 @@ func InitRoute(api *gin.Engine) {
 		userRoute(v1)
 		addressRoute(v1)
 		areaRoute(v1)
+		scheduleRoute(v1)
 	}
 
 	// Swagger
@@ -160,4 +167,40 @@ func areaRoute(r *gin.RouterGroup) {
 
 	group = r.Group("/facilities/:facility_id/areas")
 	group.GET("", h.FetchByFacilityId)
+}
+
+func scheduleRoute(r *gin.RouterGroup) {
+	scheduleRepository := repository.NewScheduleRepository()
+	facilityRepository := repository.NewFacilityRepository()
+	scheduleTypeRepository := repository.NewScheduleTypeRepository()
+	userRepository := repository.NewUserRepository()
+	recurringScheduleRepository := repository.NewRecurringScheduleRepository()
+	recurringRuleRepository := repository.NewRecurringRuleRepository()
+	addressRepository := repository.NewAddressRepository()
+	routeRepository := repository.NewRouteRepository()
+	patientRepository := repository.NewPatientRepository()
+	visitInfoRepository := repository.NewVisitInfoRepository()
+	serviceCodeRepository := repository.NewServiceCodeRepository()
+	visitCategoryRepository := repository.NewVisitCategoryRepository()
+	routeService := routeDomain.NewRouteService(
+		routeRepository,
+		addressRepository,
+	)
+	visitInfoService := visitInfoDomain.NewVisitInfoService(
+		visitInfoRepository,
+		patientRepository,
+		userRepository,
+		serviceCodeRepository,
+		routeService,
+		visitCategoryRepository,
+	)
+	h := schedulePre.NewHandler(
+		scheduleUse.NewCreateScheduleUseCase(scheduleRepository, facilityRepository, scheduleTypeRepository, userRepository, recurringScheduleRepository, visitInfoService),
+		recurringScheduleUse.NewCreateRecurringScheduleUseCase(recurringRuleRepository, facilityRepository, scheduleTypeRepository, userRepository, recurringScheduleRepository, visitInfoService),
+	)
+	group := r.Group("/facilities/:facility_id/schedules")
+	group.POST("", h.CreateSchedule)
+
+	group = r.Group("/facilities/:facility_id/schedules/recurring")
+	group.POST("", h.CreateRecurringSchedule)
 }

--- a/internal/usecase/schedule/create_schedule_use_case.go
+++ b/internal/usecase/schedule/create_schedule_use_case.go
@@ -52,7 +52,6 @@ type CreateUseCaseInputDto struct {
 	Description         *string
 	VisitInfo           *visitInfoDomain.VisitInfoModel
 	RecurringScheduleID *string
-	ScheduleCancelID    *string
 }
 
 func (uc *CreateScheduleUseCase) Run(ctx context.Context, input CreateUseCaseInputDto) (*scheduleDomain.Schedule, error) {

--- a/internal/usecase/schedule/create_schedule_use_case.go
+++ b/internal/usecase/schedule/create_schedule_use_case.go
@@ -1,0 +1,100 @@
+package schedule
+
+import (
+	"api-buddy/domain/common"
+	facilityDomain "api-buddy/domain/facility"
+	scheduleDomain "api-buddy/domain/schedule"
+	recurringScheduleDomain "api-buddy/domain/schedule/recurring_schedule"
+	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
+	userDomain "api-buddy/domain/user"
+	visitInfoDomain "api-buddy/domain/visit_info"
+	"context"
+)
+
+type CreateScheduleUseCase struct {
+	scheduleRepository          scheduleDomain.ScheduleRepository
+	facilityRepository          facilityDomain.FacilityRepository
+	scheduleTypeRepository      scheduleTypeDomain.ScheduleTypeRepository
+	userRepository              userDomain.UserRepository
+	recurringScheduleRepository recurringScheduleDomain.RecurringScheduleRepository
+	visitInfoService            *visitInfoDomain.VisitInfoService
+}
+
+type CreateUseCaseInputDto struct {
+	ScheduleTypeID      string
+	Date                common.Date
+	StartTime           common.Time
+	EndTime             common.Time
+	StaffID             string
+	FacilityID          string
+	Title               *string
+	Description         *string
+	VisitInfo           *visitInfoDomain.VisitInfoModel
+	RecurringScheduleID *string
+	ScheduleCancelID    *string
+}
+
+func (uc *CreateScheduleUseCase) Run(ctx context.Context, input CreateUseCaseInputDto) (*scheduleDomain.Schedule, error) {
+	scheduleOptions := []scheduleDomain.ScheduleOption{}
+	// 予定の種類を取得
+	scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// スタッフを取得
+	staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 施設を取得
+	facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 通常予定の場合
+	if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
+		scheduleOptions = append(scheduleOptions, scheduleDomain.WithTitle(*input.Title))
+	}
+
+	// 訪問情報がある場合
+	if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
+		// 訪問情報の作成
+		visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, *input.VisitInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		scheduleOptions = append(scheduleOptions, scheduleDomain.WithVisitInfo(visitInfo))
+	}
+
+	// 予定の説明がある場合
+	if input.Description != nil {
+		scheduleOptions = append(scheduleOptions, scheduleDomain.WithDescription(*input.Description))
+	}
+
+	// 繰り返し予定の変更予定の場合
+	if input.RecurringScheduleID != nil {
+		recurringSchedule, err := uc.recurringScheduleRepository.FindByID(ctx, *input.RecurringScheduleID)
+		if err != nil {
+			return nil, err
+		}
+		scheduleOptions = append(scheduleOptions, scheduleDomain.WithRecurringSchedule(recurringSchedule))
+	}
+
+	// 予定のインスタンスを生成
+	schedule, err := scheduleDomain.NewSchedule(scheduleType, input.Date, input.StartTime, input.EndTime, staff, facility, scheduleOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	// 予定を登録
+	err = uc.scheduleRepository.Create(ctx, schedule)
+	if err != nil {
+		return nil, err
+	}
+
+	return schedule, nil
+}

--- a/internal/usecase/schedule/create_schedule_use_case.go
+++ b/internal/usecase/schedule/create_schedule_use_case.go
@@ -8,7 +8,10 @@ import (
 	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
 	userDomain "api-buddy/domain/user"
 	visitInfoDomain "api-buddy/domain/visit_info"
+	"api-buddy/infrastructure/mysql/db"
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type CreateScheduleUseCase struct {
@@ -53,63 +56,72 @@ type CreateUseCaseInputDto struct {
 }
 
 func (uc *CreateScheduleUseCase) Run(ctx context.Context, input CreateUseCaseInputDto) (*scheduleDomain.Schedule, error) {
-	scheduleOptions := []scheduleDomain.ScheduleOption{}
-	// 予定の種類を取得
-	scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
-	if err != nil {
-		return nil, err
-	}
+	var schedule *scheduleDomain.Schedule
 
-	// スタッフを取得
-	staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
-	if err != nil {
-		return nil, err
-	}
+	err := db.WithTransaction(ctx, func(tx *gorm.DB) error {
+		// スケジュールオプションの初期化
+		scheduleOptions := []scheduleDomain.ScheduleOption{}
 
-	// 施設を取得
-	facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
-	if err != nil {
-		return nil, err
-	}
-
-	// 通常予定の場合
-	if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
-		scheduleOptions = append(scheduleOptions, scheduleDomain.WithTitle(*input.Title))
-	}
-
-	// 訪問情報がある場合
-	if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
-		// 訪問情報の作成
-		visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, *input.VisitInfo)
+		// 予定の種類を取得
+		scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		scheduleOptions = append(scheduleOptions, scheduleDomain.WithVisitInfo(visitInfo))
-	}
-
-	// 予定の説明がある場合
-	if input.Description != nil {
-		scheduleOptions = append(scheduleOptions, scheduleDomain.WithDescription(*input.Description))
-	}
-
-	// 繰り返し予定の変更予定の場合
-	if input.RecurringScheduleID != nil {
-		recurringSchedule, err := uc.recurringScheduleRepository.FindByID(ctx, *input.RecurringScheduleID)
+		// スタッフを取得
+		staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		scheduleOptions = append(scheduleOptions, scheduleDomain.WithRecurringSchedule(recurringSchedule))
-	}
 
-	// 予定のインスタンスを生成
-	schedule, err := scheduleDomain.NewSchedule(scheduleType, input.Date, input.StartTime, input.EndTime, staff, facility, scheduleOptions...)
-	if err != nil {
-		return nil, err
-	}
+		// 施設を取得
+		facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
+		if err != nil {
+			return err
+		}
 
-	// 予定を登録
-	err = uc.scheduleRepository.Create(ctx, schedule)
+		// 通常予定の場合
+		if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
+			scheduleOptions = append(scheduleOptions, scheduleDomain.WithTitle(*input.Title))
+		}
+
+		// 訪問情報がある場合
+		if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
+			visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, tx, *input.VisitInfo)
+			if err != nil {
+				return err
+			}
+			scheduleOptions = append(scheduleOptions, scheduleDomain.WithVisitInfo(visitInfo))
+		}
+
+		// 予定の説明がある場合
+		if input.Description != nil {
+			scheduleOptions = append(scheduleOptions, scheduleDomain.WithDescription(*input.Description))
+		}
+
+		// 繰り返し予定の変更予定の場合
+		if input.RecurringScheduleID != nil {
+			recurringSchedule, err := uc.recurringScheduleRepository.FindByID(ctx, *input.RecurringScheduleID)
+			if err != nil {
+				return err
+			}
+			scheduleOptions = append(scheduleOptions, scheduleDomain.WithRecurringSchedule(recurringSchedule))
+		}
+
+		// 予定のインスタンスを生成
+		schedule, err = scheduleDomain.NewSchedule(scheduleType, input.Date, input.StartTime, input.EndTime, staff, facility, scheduleOptions...)
+		if err != nil {
+			return err
+		}
+
+		// 予定を登録
+		if err := uc.scheduleRepository.Create(ctx, tx, schedule); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/schedule/create_schedule_use_case.go
+++ b/internal/usecase/schedule/create_schedule_use_case.go
@@ -20,6 +20,24 @@ type CreateScheduleUseCase struct {
 	visitInfoService            *visitInfoDomain.VisitInfoService
 }
 
+func NewCreateScheduleUseCase(
+	scheduleRepository scheduleDomain.ScheduleRepository,
+	facilityRepository facilityDomain.FacilityRepository,
+	scheduleTypeRepository scheduleTypeDomain.ScheduleTypeRepository,
+	userRepository userDomain.UserRepository,
+	recurringScheduleRepository recurringScheduleDomain.RecurringScheduleRepository,
+	visitInfoService *visitInfoDomain.VisitInfoService,
+) *CreateScheduleUseCase {
+	return &CreateScheduleUseCase{
+		scheduleRepository:          scheduleRepository,
+		facilityRepository:          facilityRepository,
+		scheduleTypeRepository:      scheduleTypeRepository,
+		userRepository:              userRepository,
+		recurringScheduleRepository: recurringScheduleRepository,
+		visitInfoService:            visitInfoService,
+	}
+}
+
 type CreateUseCaseInputDto struct {
 	ScheduleTypeID      string
 	Date                common.Date

--- a/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
+++ b/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
@@ -8,7 +8,10 @@ import (
 	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
 	userDomain "api-buddy/domain/user"
 	visitInfoDomain "api-buddy/domain/visit_info"
+	"api-buddy/infrastructure/mysql/db"
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type CreateRecurringScheduleUseCase struct {
@@ -61,101 +64,109 @@ type RecurringRuleModel struct {
 }
 
 func (uc *CreateRecurringScheduleUseCase) Run(ctx context.Context, input CreateRecurringScheduleUseCaseInputDto) (*recurringScheduleDomain.RecurringSchedule, error) {
-	recurringScheduleOptions := []recurringScheduleDomain.RecurringScheduleOption{}
-	// 予定の種類を取得
-	scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
-	if err != nil {
-		return nil, err
-	}
+	var recurringSchedule *recurringScheduleDomain.RecurringSchedule
 
-	// スタッフを取得
-	staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
-	if err != nil {
-		return nil, err
-	}
+	err := db.WithTransaction(ctx, func(tx *gorm.DB) error {
+		recurringScheduleOptions := []recurringScheduleDomain.RecurringScheduleOption{}
 
-	// 施設を取得
-	facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
-	if err != nil {
-		return nil, err
-	}
-
-	recurringScheduleRuleOptions := []recurringRuleDomain.RecurringRuleOption{}
-
-	// 曜日が指定されている場合
-	if input.RecurringRule.DaysOfWeek != nil {
-		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDaysOfWeek(*input.RecurringRule.DaysOfWeek))
-	}
-
-	// 月の日が指定されている場合
-	if input.RecurringRule.DayOfMonth != nil {
-		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDayOfMonth(*input.RecurringRule.DayOfMonth))
-	}
-
-	// 週の日が指定されている場合
-	if input.RecurringRule.WeekOfMonth != nil {
-		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithWeekOfMonth(*input.RecurringRule.WeekOfMonth))
-	}
-
-	// 終了日が指定されている場合
-	if input.RecurringRule.EndDate != nil {
-		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithEndDate(*input.RecurringRule.EndDate))
-	}
-
-	// リクエストされた繰り返しルールを作成
-	recurringRule, err := recurringRuleDomain.NewRecurringRule(
-		input.RecurringRule.Frequency,
-		input.RecurringRule.StartDate,
-		recurringScheduleRuleOptions...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// 繰り返しルールの登録
-	err = uc.recurringRuleRepository.Create(ctx, recurringRule)
-	if err != nil {
-		return nil, err
-	}
-
-	// 通常予定の場合
-	if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
-		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithTitle(*input.Title))
-	}
-
-	// 訪問情報がある場合
-	if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
-		// 訪問情報の作成
-		visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, *input.VisitInfo)
+		// 予定の種類を取得
+		scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithVisitInfo(visitInfo))
-	}
+		// スタッフを取得
+		staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
+		if err != nil {
+			return err
+		}
 
-	// 予定の説明がある場合
-	if input.Description != nil {
-		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithDescription(*input.Description))
-	}
+		// 施設を取得
+		facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
+		if err != nil {
+			return err
+		}
 
-	// 繰り返し予定の作成
-	recurringSchedule, err := recurringScheduleDomain.NewRecurringSchedule(
-		recurringRule,
-		scheduleType,
-		input.Date,
-		input.StartTime,
-		input.EndTime,
-		staff,
-		facility,
-		recurringScheduleOptions...,
-	)
-	if err != nil {
-		return nil, err
-	}
+		recurringScheduleRuleOptions := []recurringRuleDomain.RecurringRuleOption{}
 
-	// 繰り返し予定を登録
-	err = uc.recurringScheduleRepository.Create(ctx, recurringSchedule)
+		// 曜日が指定されている場合
+		if input.RecurringRule.DaysOfWeek != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDaysOfWeek(*input.RecurringRule.DaysOfWeek))
+		}
+
+		// 月の日が指定されている場合
+		if input.RecurringRule.DayOfMonth != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDayOfMonth(*input.RecurringRule.DayOfMonth))
+		}
+
+		// 週の日が指定されている場合
+		if input.RecurringRule.WeekOfMonth != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithWeekOfMonth(*input.RecurringRule.WeekOfMonth))
+		}
+
+		// 終了日が指定されている場合
+		if input.RecurringRule.EndDate != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithEndDate(*input.RecurringRule.EndDate))
+		}
+
+		// リクエストされた繰り返しルールを作成
+		recurringRule, err := recurringRuleDomain.NewRecurringRule(
+			input.RecurringRule.Frequency,
+			input.RecurringRule.StartDate,
+			recurringScheduleRuleOptions...,
+		)
+		if err != nil {
+			return err
+		}
+
+		// 繰り返しルールの登録
+		if err := uc.recurringRuleRepository.Create(ctx, tx, recurringRule); err != nil {
+			return err
+		}
+
+		// 通常予定の場合
+		if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
+			recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithTitle(*input.Title))
+		}
+
+		// 訪問情報がある場合
+		if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
+			visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, tx, *input.VisitInfo)
+			if err != nil {
+				return err
+			}
+
+			recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithVisitInfo(visitInfo))
+		}
+
+		// 予定の説明がある場合
+		if input.Description != nil {
+			recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithDescription(*input.Description))
+		}
+
+		// 繰り返し予定の作成
+		recurringSchedule, err = recurringScheduleDomain.NewRecurringSchedule(
+			recurringRule,
+			scheduleType,
+			input.Date,
+			input.StartTime,
+			input.EndTime,
+			staff,
+			facility,
+			recurringScheduleOptions...,
+		)
+		if err != nil {
+			return err
+		}
+
+		// 繰り返し予定を登録
+		if err := uc.recurringScheduleRepository.Create(ctx, tx, recurringSchedule); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
+++ b/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
@@ -56,7 +56,7 @@ type CreateRecurringScheduleUseCaseInputDto struct {
 
 type RecurringRuleModel struct {
 	Frequency   recurringRuleDomain.FrequencyEnum
-	DaysOfWeek  *int
+	DayOfWeek   *int
 	DayOfMonth  *int
 	WeekOfMonth *int
 	StartDate   common.Date
@@ -90,8 +90,8 @@ func (uc *CreateRecurringScheduleUseCase) Run(ctx context.Context, input CreateR
 		recurringScheduleRuleOptions := []recurringRuleDomain.RecurringRuleOption{}
 
 		// 曜日が指定されている場合
-		if input.RecurringRule.DaysOfWeek != nil {
-			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDaysOfWeek(*input.RecurringRule.DaysOfWeek))
+		if input.RecurringRule.DayOfWeek != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDayOfWeek(*input.RecurringRule.DayOfWeek))
 		}
 
 		// 月の日が指定されている場合

--- a/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
+++ b/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
@@ -20,6 +20,24 @@ type CreateRecurringScheduleUseCase struct {
 	visitInfoService            *visitInfoDomain.VisitInfoService
 }
 
+func NewCreateRecurringScheduleUseCase(
+	recurringRuleRepository recurringRuleDomain.RecurringRuleRepository,
+	facilityRepository facilityDomain.FacilityRepository,
+	scheduleTypeRepository scheduleTypeDomain.ScheduleTypeRepository,
+	userRepository userDomain.UserRepository,
+	recurringScheduleRepository recurringScheduleDomain.RecurringScheduleRepository,
+	visitInfoService *visitInfoDomain.VisitInfoService,
+) *CreateRecurringScheduleUseCase {
+	return &CreateRecurringScheduleUseCase{
+		recurringRuleRepository:     recurringRuleRepository,
+		facilityRepository:          facilityRepository,
+		scheduleTypeRepository:      scheduleTypeRepository,
+		userRepository:              userRepository,
+		recurringScheduleRepository: recurringScheduleRepository,
+		visitInfoService:            visitInfoService,
+	}
+}
+
 type CreateRecurringScheduleUseCaseInputDto struct {
 	ScheduleTypeID string
 	RecurringRule  RecurringRuleModel

--- a/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
+++ b/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
@@ -1,0 +1,146 @@
+package recurring_schedule
+
+import (
+	"api-buddy/domain/common"
+	facilityDomain "api-buddy/domain/facility"
+	recurringRuleDomain "api-buddy/domain/schedule/recurring_rule"
+	recurringScheduleDomain "api-buddy/domain/schedule/recurring_schedule"
+	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
+	userDomain "api-buddy/domain/user"
+	visitInfoDomain "api-buddy/domain/visit_info"
+	"context"
+)
+
+type CreateRecurringScheduleUseCase struct {
+	recurringRuleRepository     recurringRuleDomain.RecurringRuleRepository
+	facilityRepository          facilityDomain.FacilityRepository
+	scheduleTypeRepository      scheduleTypeDomain.ScheduleTypeRepository
+	userRepository              userDomain.UserRepository
+	recurringScheduleRepository recurringScheduleDomain.RecurringScheduleRepository
+	visitInfoService            *visitInfoDomain.VisitInfoService
+}
+
+type CreateRecurringScheduleUseCaseInputDto struct {
+	ScheduleTypeID string
+	RecurringRule  RecurringRuleModel
+	Date           common.Date
+	StartTime      common.Time
+	EndTime        common.Time
+	StaffID        string
+	FacilityID     string
+	Title          *string
+	Description    *string
+	VisitInfo      *visitInfoDomain.VisitInfoModel
+}
+
+type RecurringRuleModel struct {
+	Frequency   recurringRuleDomain.FrequencyEnum
+	DaysOfWeek  *int
+	DayOfMonth  *int
+	WeekOfMonth *int
+	StartDate   common.Date
+	EndDate     *common.Date
+}
+
+func (uc *CreateRecurringScheduleUseCase) Run(ctx context.Context, input CreateRecurringScheduleUseCaseInputDto) (*recurringScheduleDomain.RecurringSchedule, error) {
+	recurringScheduleOptions := []recurringScheduleDomain.RecurringScheduleOption{}
+	// 予定の種類を取得
+	scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// スタッフを取得
+	staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 施設を取得
+	facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
+	if err != nil {
+		return nil, err
+	}
+
+	recurringScheduleRuleOptions := []recurringRuleDomain.RecurringRuleOption{}
+
+	// 曜日が指定されている場合
+	if input.RecurringRule.DaysOfWeek != nil {
+		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDaysOfWeek(*input.RecurringRule.DaysOfWeek))
+	}
+
+	// 月の日が指定されている場合
+	if input.RecurringRule.DayOfMonth != nil {
+		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDayOfMonth(*input.RecurringRule.DayOfMonth))
+	}
+
+	// 週の日が指定されている場合
+	if input.RecurringRule.WeekOfMonth != nil {
+		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithWeekOfMonth(*input.RecurringRule.WeekOfMonth))
+	}
+
+	// 終了日が指定されている場合
+	if input.RecurringRule.EndDate != nil {
+		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithEndDate(*input.RecurringRule.EndDate))
+	}
+
+	// リクエストされた繰り返しルールを作成
+	recurringRule, err := recurringRuleDomain.NewRecurringRule(
+		input.RecurringRule.Frequency,
+		input.RecurringRule.StartDate,
+		recurringScheduleRuleOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// 繰り返しルールの登録
+	err = uc.recurringRuleRepository.Create(ctx, recurringRule)
+	if err != nil {
+		return nil, err
+	}
+
+	// 通常予定の場合
+	if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
+		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithTitle(*input.Title))
+	}
+
+	// 訪問情報がある場合
+	if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
+		// 訪問情報の作成
+		visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, *input.VisitInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithVisitInfo(visitInfo))
+	}
+
+	// 予定の説明がある場合
+	if input.Description != nil {
+		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithDescription(*input.Description))
+	}
+
+	// 繰り返し予定の作成
+	recurringSchedule, err := recurringScheduleDomain.NewRecurringSchedule(
+		recurringRule,
+		scheduleType,
+		input.Date,
+		input.StartTime,
+		input.EndTime,
+		staff,
+		facility,
+		recurringScheduleOptions...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// 繰り返し予定を登録
+	err = uc.recurringScheduleRepository.Create(ctx, recurringSchedule)
+	if err != nil {
+		return nil, err
+	}
+
+	return recurringSchedule, nil
+}

--- a/internal/usecase/schedule/schedule_type/fetch_schedule_types.go
+++ b/internal/usecase/schedule/schedule_type/fetch_schedule_types.go
@@ -1,0 +1,38 @@
+package schedule_type
+
+import (
+	"api-buddy/domain/schedule/schedule_type"
+	"context"
+)
+
+type FetchScheduleTypesUseCase struct {
+	scheduleTypeRepository schedule_type.ScheduleTypeRepository
+}
+
+func NewFetchScheduleTypesUseCase(scheduleTypeRepository schedule_type.ScheduleTypeRepository) *FetchScheduleTypesUseCase {
+	return &FetchScheduleTypesUseCase{
+		scheduleTypeRepository: scheduleTypeRepository,
+	}
+}
+
+type FetchScheduleTypesUseCaseOutputDto struct {
+	ID   string
+	Name schedule_type.ScheduleTypeEnum
+}
+
+func (uc *FetchScheduleTypesUseCase) Run(ctx context.Context, facilityId string) ([]FetchScheduleTypesUseCaseOutputDto, error) {
+	scheduleTypes, err := uc.scheduleTypeRepository.FindAll(ctx, facilityId)
+	if err != nil {
+		return nil, err
+	}
+
+	var outputDto []FetchScheduleTypesUseCaseOutputDto
+	for _, scheduleType := range scheduleTypes {
+		outputDto = append(outputDto, FetchScheduleTypesUseCaseOutputDto{
+			ID:   scheduleType.ID,
+			Name: scheduleType.Name,
+		})
+	}
+
+	return outputDto, nil
+}

--- a/internal/usecase/visit_info/service_code/fetch_service_codes_use_case.go
+++ b/internal/usecase/visit_info/service_code/fetch_service_codes_use_case.go
@@ -1,0 +1,42 @@
+package service_code
+
+import (
+	"api-buddy/domain/visit_info/service_code"
+	"context"
+)
+
+type FetchServiceCodesUseCase struct {
+	serviceCodeRepository service_code.ServiceCodeRepository
+}
+
+func NewFetchServiceCodesUseCase(serviceCodeRepository service_code.ServiceCodeRepository) *FetchServiceCodesUseCase {
+	return &FetchServiceCodesUseCase{
+		serviceCodeRepository: serviceCodeRepository,
+	}
+}
+
+type FetchServiceCodesUseCaseOutputDto struct {
+	ID                    string
+	Code                  string
+	ServiceTimeRangeStart int
+	ServiceTimeRangeEnd   int
+}
+
+func (uc *FetchServiceCodesUseCase) Run(ctx context.Context) ([]FetchServiceCodesUseCaseOutputDto, error) {
+	serviceCodes, err := uc.serviceCodeRepository.FindAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var outputDto []FetchServiceCodesUseCaseOutputDto
+	for _, serviceCode := range serviceCodes {
+		outputDto = append(outputDto, FetchServiceCodesUseCaseOutputDto{
+			ID:                    serviceCode.ID,
+			Code:                  serviceCode.Code,
+			ServiceTimeRangeStart: serviceCode.ServiceTimeRangeStart,
+			ServiceTimeRangeEnd:   serviceCode.ServiceTimeRangeEnd,
+		})
+	}
+
+	return outputDto, nil
+}

--- a/internal/usecase/visit_info/visit_category/visit_category_use_case.go
+++ b/internal/usecase/visit_info/visit_category/visit_category_use_case.go
@@ -1,0 +1,38 @@
+package visit_category
+
+import (
+	"api-buddy/domain/visit_info/visit_category"
+	"context"
+)
+
+type FetchVisitCategoriesUseCase struct {
+	visitCategoryRepository visit_category.VisitCategoryRepository
+}
+
+func NewFetchVisitCategoriesUseCase(visitCategoryRepository visit_category.VisitCategoryRepository) *FetchVisitCategoriesUseCase {
+	return &FetchVisitCategoriesUseCase{
+		visitCategoryRepository: visitCategoryRepository,
+	}
+}
+
+type FetchVisitCategoriesUseCaseOutputDto struct {
+	ID   string
+	Name visit_category.VisitCategoryType
+}
+
+func (uc *FetchVisitCategoriesUseCase) Run(ctx context.Context) ([]FetchVisitCategoriesUseCaseOutputDto, error) {
+	visitCategories, err := uc.visitCategoryRepository.FindAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var outputDto []FetchVisitCategoriesUseCaseOutputDto
+	for _, visitCategory := range visitCategories {
+		outputDto = append(outputDto, FetchVisitCategoriesUseCaseOutputDto{
+			ID:   visitCategory.ID,
+			Name: visitCategory.Name,
+		})
+	}
+
+	return outputDto, nil
+}


### PR DESCRIPTION
## 関連：issue・Ticket
issue：#27 
予定登録処理にトランザクションを追加：#32 
実装の方針：https://tin-lifeboat-9a8.notion.site/16b3b3f9682e804da9f0dd094c7aeaf5?pvs=4

## 概要
## domain層

### 予定関連

![image](https://github.com/user-attachments/assets/b1f1be5a-318b-491f-b244-4770559841f9)

- 予定
    - 訪問種別が通常の場合
        - [x]  titleが含まれていること
    - 通常予定の場合、タイトルは必須であること
    - 終了時間が開始時間よりも後であること
    - 繰り返し予定の変更の場合
        - [x]  受け取ったIDを元にDBに存在するかチェック
    - [x]  訪問情報が任意であること
- 繰り返し予定
    - 除外日の日付を管理できること（更新時に実装）
- 繰り返しルール
    - Frequency = monthryの場合
        - [x]  月の日付が存在すること
        - [x]  曜日・週の日が空であること
    - Frequency = weeklyの場合
        - [x]  月の日付がからであること
        - [x]  曜日・週の日が存在すること
    - [x]  月の日付が1〜31の間であること
    - [x]  曜日が1〜7の間であること
    - [x]  月の週が1〜5の間であること
- 予定の種別
    - 訪問・通常
- キャンセル情報
    - 更新時に実装

### 訪問関連

![image](https://github.com/user-attachments/assets/e06c7c55-88f5-4d95-861a-046744a059b3)

- ルート
- サービスコード
- 訪問情報
    - [x]  ルートは任意であること
- 訪問カテゴリ
    - 緊急・入院・夜勤
    - 加算項目で必要になる

## Usecase層

domain,repositry層でのエラーをpresentationに流す。

- トランザクションの追加
- [[予定登録失敗時に訪問情報のデータだけ保存される](https://www.notion.so/16d3b3f9682e80c8b4a6d794bbb0f09d?pvs=21)](https://www.notion.so/16d3b3f9682e80c8b4a6d794bbb0f09d?pvs=21)
    - 訪問情報登録後、予定登録に失敗した場合はロールバックするように

## Prsentation層

- pathParamのチェック
    - UUIDの形式であること
- bodyのチェック
    - 必須項目、型の確認
    - 

[[Buddy：エラーハンドリングとレスポンス設計](https://www.notion.so/Buddy-1183b3f9682e80a982d4ece2cee7e6ec?pvs=21)](https://www.notion.so/Buddy-1183b3f9682e80a982d4ece2cee7e6ec?pvs=21) を参考に

- 入力値の型チェック、必須項目の確認
    - 400エラー


### 実行結果

| 名前 | 画像 | 
| ---|---|
| 訪問予定 |![image](https://github.com/user-attachments/assets/9f2944df-3282-424e-96d7-eeee58c67ad4) |
| 通常予定 |![image](https://github.com/user-attachments/assets/678bd127-36ab-47bf-8918-7c78c357ca0d) |
|繰り返し予定|![image](https://github.com/user-attachments/assets/60d8c0a0-4d54-4b47-87dd-bb43a96c8318)|


## 変更点

- domain層でFOPを採用
-

## 今後やること

- [ ] テストの追加
- [ ] リファクタリング
- [ ] 他のdomain層でもFOPを利用した実装に変更する


## 参考
