### PR TITLE
ユーザーのモデルの単体テストを追加 #9

### DIFF
--- a/internal/domain/common/model.go
+++ b/internal/domain/common/model.go
@@ -1,6 +1,9 @@
 package common
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // カスタム共通モデル
 type CommonModel struct {
@@ -16,7 +19,30 @@ func InitializeCommonModel(m *CommonModel) {
 }
 
 func AddPlusToPhoneNumber(phoneNumber string) string {
-	return "+" + phoneNumber
+	if phoneNumber[0] != '+' {
+		phoneNumber = "+" + phoneNumber
+	}
+	return phoneNumber
+}
+
+func IsPhoneNumber(phoneNumber string) bool {
+	for _, c := range phoneNumber {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func IsEmail(email string) bool {
+	// 文字列に@と.が含まれているかチェック
+	if !strings.Contains(email, "@") || !strings.Contains(email, ".") {
+		return false
+	}
+	return true
+}
+func StringPointer(s string) *string {
+	return &s
 }
 
 const (

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -122,6 +122,12 @@ func newUser(
 	// Optionがnilでない場合のみ、EmailとPhoneNumberを設定
 	if options != nil {
 		if options.Email != nil {
+			// Emailが正しい形式かチェック
+			if !common.IsEmail(*options.Email) {
+				err := errorDomain.NewError("Emailの形式が正しくありません")
+				return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+			}
+			// Emailが320文字以上の場合はエラーを返す
 			if len(*options.Email) > 320 {
 				err := errorDomain.NewError("Emailは320文字以内です")
 				return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
@@ -130,11 +136,17 @@ func newUser(
 		}
 
 		if options.PhoneNumber != nil {
+			// phoneNumberは数字のみで構成されているかチェック
+			if !common.IsPhoneNumber(*options.PhoneNumber) {
+				err := errorDomain.NewError("電話番号は数字のみで構成されています")
+				return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
+			}
+			// 電話番号が11文字以上の場合はエラーを返す
 			if len(*options.PhoneNumber) > 11 {
 				err := errorDomain.NewError("電話番号は11文字以内です")
 				return nil, errorDomain.WrapError(errorDomain.InvalidInputErr, err)
 			}
-			// 先頭に"+"を加える処理を追加
+			// 先頭に"+"がない場合、"+"を加える処理を追加
 			*options.PhoneNumber = common.AddPlusToPhoneNumber(*options.PhoneNumber)
 			user.PhoneNumber = *options.PhoneNumber
 		}

--- a/internal/domain/user/user_test.go
+++ b/internal/domain/user/user_test.go
@@ -1,0 +1,108 @@
+package user_test
+
+import (
+	"api-buddy/domain/common"
+	errorDomain "api-buddy/domain/error"
+	facilityDomain "api-buddy/domain/facility"
+	areaDomain "api-buddy/domain/facility/area"
+	departmentDomain "api-buddy/domain/facility/department"
+	positionDomain "api-buddy/domain/facility/position"
+	teamDomain "api-buddy/domain/facility/team"
+	"api-buddy/domain/policy"
+	userDomain "api-buddy/domain/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewUser(t *testing.T) {
+	// 正常値の定義
+	trueName := "test_user"
+	facility := &facilityDomain.Facility{ID: "facility_1"}
+	department := &departmentDomain.Department{ID: "department_1"}
+	position := &positionDomain.Position{ID: "position_1"}
+	team := &teamDomain.Team{ID: "team_1"}
+	area := &areaDomain.Area{ID: "area_1"}
+	policies := []*policy.Policy{{ID: "policy_1"}, {ID: "policy_2"}}
+	trueEmail := "test@example.com"
+	truePhoneNumber := "09012345678"
+
+	// テストケースの定義
+	cases := map[string]struct {
+		username     string
+		options      *userDomain.Option
+		wantErrorMsg string
+	}{
+		"正常系": {
+			username: trueName,
+			options: &userDomain.Option{
+				Email:       &trueEmail,
+				PhoneNumber: &truePhoneNumber,
+			},
+			wantErrorMsg: "",
+		},
+		"異常系: ユーザー名が128文字以上": {
+			username: "Il2wTMIUYSgYc3oRBwKjx1O2STuuur32vXR06k3Pqu3OahfWE1xR7yWXeBft8utbkfQh1v66TowFixygHKuUbSIr5NUrs00NMCvaLlHSAsAL0QvLpCKn8Hj2jMxJhUOSp",
+			options: &userDomain.Option{
+				Email:       &trueEmail,
+				PhoneNumber: &truePhoneNumber,
+			},
+			wantErrorMsg: errorDomain.NewError("ユーザー名は128文字以内です").Error(),
+		},
+		"異常系：メールアドレスが正しい形式でない": {
+			username: trueName,
+			options: &userDomain.Option{
+				Email:       common.StringPointer("testexample.com"),
+				PhoneNumber: &truePhoneNumber,
+			},
+			wantErrorMsg: errorDomain.NewError("Emailの形式が正しくありません").Error(),
+		},
+		"異常系: メールアドレスが320文字以上": {
+			username: trueName,
+			options: &userDomain.Option{
+				Email:       common.StringPointer("MQ8GaEaSPw8p1ngbSsNXiFgRPK21fwPTIHl2N7aLUW8hOo5xi8UnAHHKqh62FBMTrmheUUbD6FCA0MP2yI2TbVCyxrUpokE0PcEcMQ5xdKn3YL0U7MdgYsiGDAvGJHSEVO4i5NcWs4X8NPMVRg4IW0McN8ga07pttL6TNytGGofk@EQhGG6OpTPP4rOkWAkWlrn3bdObfN658LHvheDxseoHacEnWVlJibMYatQVuFsuBS8tu1nQJTclx5AdWl6XvrDK2qkVQcQBN3DAlgmyYmYeJTaYg7m7aoTfkn1QI.MaJFoUxKxg1U03WgqYfeac8g"),
+				PhoneNumber: &truePhoneNumber,
+			},
+			wantErrorMsg: errorDomain.NewError("Emailは320文字以内です").Error(),
+		},
+		"異常系: 電話番号が数字以外を含む": {
+			username: trueName,
+			options: &userDomain.Option{
+				Email:       &trueEmail,
+				PhoneNumber: common.StringPointer("0901234567a"),
+			},
+			wantErrorMsg: errorDomain.NewError("電話番号は数字のみで構成されています").Error(),
+		},
+		"異常系: 電話番号が11文字以上": {
+			username: trueName,
+			options: &userDomain.Option{
+				Email:       &trueEmail,
+				PhoneNumber: common.StringPointer("090123456789"),
+			},
+			wantErrorMsg: errorDomain.NewError("電話番号は11文字以内です").Error(),
+		},
+	}
+
+	// テストケースの実行
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			user, err := userDomain.NewUser(tt.username, position, team, facility, department, area, policies, tt.options)
+
+			if tt.wantErrorMsg == "" {
+				assert.NotNil(t, user)
+				assert.Equal(t, tt.username, user.Username)
+				if tt.options.Email != nil {
+					assert.Equal(t, *tt.options.Email, user.Email)
+				}
+				if tt.options.PhoneNumber != nil {
+					assert.Equal(t, *tt.options.PhoneNumber, user.PhoneNumber)
+				}
+			} else {
+				assert.Error(t, err)
+				if err != nil {
+					assert.Equal(t, tt.wantErrorMsg, err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 関連：issue・Ticket
#9 

## 概要

モデルのテストを実装し、テストの方針を固めた。
### 実装の方針
基本的にTable-Driven-Testで実装する。
ドメインモデルでは、各プロパティの文字数などの制約事項を満たしているかを判定するため、各プロパティの制約が保証されているかをテストする


### 今回のテストケース
- [x] 正常系
- [x] ユーザー名が128文字以上の場合
- [x] メールドレスが正しくない形式の場合
- [x] メールアドレスが320文字以上の場合
- [x] 電話番号に数字以外の文字列が含まれる
- [x] 電話番号が11文字以上

### テスト結果
<img width="722" alt="image" src="https://github.com/user-attachments/assets/7f30d20c-4cee-4552-9d28-f71c7912ab1e" />


## 変更点
- テストを実装するにあたり、下記の処理を追加した
  - メールアドレスの形式チェック
  - 電話番号が数字のみの文字列で構成されているか
  - 電話番号にすでに+文字がついている場合、+の文字列を付与しないように

## 今後やること

- [ ] 他のドメインモデルのテストの実装（予定、権限を中心に行う）
- [ ] リポジトリ、ユースケース層のテストの実装

## 備考
今後のテスト方針は下記にまとめていく
https://tin-lifeboat-9a8.notion.site/16b3b3f9682e8015b413c90fa2588c03?pvs=4