### PR TITLE
予定登録の処理にトランザクションを追加 #30

### DIFF
--- a/internal/domain/schedule/recurring_rule/recurring_rule_repository.go
+++ b/internal/domain/schedule/recurring_rule/recurring_rule_repository.go
@@ -2,10 +2,12 @@ package recurring_rule
 
 import (
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type RecurringRuleRepository interface {
 	FindByFacilityID(ctx context.Context, facility_id string) ([]*RecurringRule, error)
 	FindByID(ctx context.Context, id string) (*RecurringRule, error)
-	Create(ctx context.Context, recurring_rule *RecurringRule) error
+	Create(ctx context.Context, tx *gorm.DB, recurring_rule *RecurringRule) error
 }

--- a/internal/domain/schedule/recurring_schedule/recurring_schedule_repository.go
+++ b/internal/domain/schedule/recurring_schedule/recurring_schedule_repository.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/Fukuemon/go-pkg/query"
+	"gorm.io/gorm"
 )
 
 type RecurringScheduleRepository interface {
 	FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*RecurringSchedule, error)
 	FindByID(ctx context.Context, id string) (*RecurringSchedule, error)
-	Create(ctx context.Context, recurring_schedule *RecurringSchedule) error
+	Create(ctx context.Context, tx *gorm.DB, recurring_schedule *RecurringSchedule) error
 }

--- a/internal/domain/schedule/schedule_repository.go
+++ b/internal/domain/schedule/schedule_repository.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/Fukuemon/go-pkg/query"
+	"gorm.io/gorm"
 )
 
 type ScheduleRepository interface {
 	FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*Schedule, error)
 	FindByID(ctx context.Context, id string) (*Schedule, error)
-	Create(ctx context.Context, schedule *Schedule) error
+	Create(ctx context.Context, tx *gorm.DB, schedule *Schedule) error
 }

--- a/internal/domain/visit_info/route/route_repository.go
+++ b/internal/domain/visit_info/route/route_repository.go
@@ -1,8 +1,12 @@
 package route
 
-import "context"
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
 
 type RouteRepository interface {
 	FindByID(ctx context.Context, id string) (*Route, error)
-	Create(ctx context.Context, route *Route) error
+	Create(ctx context.Context, tx *gorm.DB, route *Route) error
 }

--- a/internal/domain/visit_info/route/route_service.go
+++ b/internal/domain/visit_info/route/route_service.go
@@ -3,6 +3,8 @@ package route
 import (
 	addressDomain "api-buddy/domain/address"
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type RouteService struct {
@@ -29,10 +31,10 @@ type RouteModel struct {
 
 func (s *RouteService) CreateRoute(
 	ctx context.Context,
+	tx *gorm.DB,
 	routeModel *RouteModel,
 ) (*Route, error) {
 
-	// 住所の再構築または新規作成
 	fromAddress, err := s.addressRepository.FindByID(ctx, routeModel.FromAddressID)
 	if err != nil {
 		return nil, err
@@ -49,7 +51,7 @@ func (s *RouteService) CreateRoute(
 		return nil, err
 	}
 
-	err = s.routeRepository.Create(ctx, route)
+	err = s.routeRepository.Create(ctx, tx, route)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/visit_info/visit_info_repository.go
+++ b/internal/domain/visit_info/visit_info_repository.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/Fukuemon/go-pkg/query"
+	"gorm.io/gorm"
 )
 
 type VisitInfoRepository interface {
-	Create(ctx context.Context, visitInfo *VisitInfo) error
+	Create(ctx context.Context, tx *gorm.DB, visitInfo *VisitInfo) error
 	FindAll(ctx context.Context, filters []query.Filter, sort query.SortOption) ([]*VisitInfo, error)
 	FindByID(ctx context.Context, id string) (*VisitInfo, error)
 }

--- a/internal/domain/visit_info/visit_info_service.go
+++ b/internal/domain/visit_info/visit_info_service.go
@@ -7,6 +7,8 @@ import (
 	serviceCodeDomain "api-buddy/domain/visit_info/service_code"
 	visitCategoryDomain "api-buddy/domain/visit_info/visit_category"
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type VisitInfoService struct {
@@ -45,10 +47,7 @@ type VisitInfoModel struct {
 	VisitCategoryIDs []*string
 }
 
-func (s *VisitInfoService) CreateVisitInfo(
-	ctx context.Context,
-	visitInfoModel VisitInfoModel,
-) (*VisitInfo, error) {
+func (s *VisitInfoService) CreateVisitInfo(ctx context.Context, tx *gorm.DB, visitInfoModel VisitInfoModel) (*VisitInfo, error) {
 	patient, err := s.patientRepository.FindByID(ctx, visitInfoModel.PatientID)
 	if err != nil {
 		return nil, err
@@ -70,7 +69,7 @@ func (s *VisitInfoService) CreateVisitInfo(
 	options := []VisitInfoOption{}
 	if visitInfoModel.Route != nil {
 		// ルートの作成
-		route, err := s.routeService.CreateRoute(ctx, visitInfoModel.Route)
+		route, err := s.routeService.CreateRoute(ctx, tx, visitInfoModel.Route)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +107,7 @@ func (s *VisitInfoService) CreateVisitInfo(
 	}
 
 	// 訪問情報の保存
-	if err := s.visitInfoRepository.Create(ctx, visitInfo); err != nil {
+	if err := s.visitInfoRepository.Create(ctx, tx, visitInfo); err != nil {
 		return nil, err
 	}
 

--- a/internal/infrastructure/mysql/db/transaction.go
+++ b/internal/infrastructure/mysql/db/transaction.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// TransactionHandler はトランザクション内での処理を定義する関数
+type TransactionHandler func(tx *gorm.DB) error
+
+// WithTransaction はトランザクションを開始し、指定されたハンドラーを実行します。
+func WithTransaction(ctx context.Context, handler TransactionHandler) error {
+	db := GetDB()
+	tx := db.Begin() // トランザクション開始
+	if tx.Error != nil {
+		return tx.Error
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+			panic(r)
+		}
+	}()
+
+	// ハンドラーを実行
+	if err := handler(tx); err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	// コミット
+	if err := tx.Commit().Error; err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/infrastructure/mysql/db/transaction.go
+++ b/internal/infrastructure/mysql/db/transaction.go
@@ -6,13 +6,11 @@ import (
 	"gorm.io/gorm"
 )
 
-// TransactionHandler はトランザクション内での処理を定義する関数
 type TransactionHandler func(tx *gorm.DB) error
 
-// WithTransaction はトランザクションを開始し、指定されたハンドラーを実行します。
 func WithTransaction(ctx context.Context, handler TransactionHandler) error {
 	db := GetDB()
-	tx := db.Begin() // トランザクション開始
+	tx := db.Begin()
 	if tx.Error != nil {
 		return tx.Error
 	}

--- a/internal/infrastructure/mysql/repository/recurring_rule_repository.go
+++ b/internal/infrastructure/mysql/repository/recurring_rule_repository.go
@@ -19,12 +19,15 @@ func NewRecurringRuleRepository() recurringRuleDomain.RecurringRuleRepository {
 	}
 }
 
-func (r *RecurringRuleRepository) Create(ctx context.Context, recurringRule *recurringRuleDomain.RecurringRule) error {
-	err := r.db.Create(recurringRule).Error
+func (r *RecurringRuleRepository) Create(ctx context.Context, tx *gorm.DB, recurringRule *recurringRuleDomain.RecurringRule) error {
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+	err := db.Create(recurringRule).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}
-
 	return nil
 }
 

--- a/internal/infrastructure/mysql/repository/recurring_schedule_repository.go
+++ b/internal/infrastructure/mysql/repository/recurring_schedule_repository.go
@@ -21,12 +21,15 @@ func NewRecurringScheduleRepository() recurringScheduleDomain.RecurringScheduleR
 	}
 }
 
-func (r *RecurringScheduleRepository) Create(ctx context.Context, recurringSchedule *recurringScheduleDomain.RecurringSchedule) error {
-	err := r.db.Create(recurringSchedule).Error
+func (r *RecurringScheduleRepository) Create(ctx context.Context, tx *gorm.DB, recurringSchedule *recurringScheduleDomain.RecurringSchedule) error {
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+	err := db.Create(recurringSchedule).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}
-
 	return nil
 }
 

--- a/internal/infrastructure/mysql/repository/route_repository.go
+++ b/internal/infrastructure/mysql/repository/route_repository.go
@@ -19,8 +19,12 @@ func NewRouteRepository() routeDomain.RouteRepository {
 	}
 }
 
-func (r *RouteRepository) Create(ctx context.Context, route *routeDomain.Route) error {
-	err := r.db.Create(route).Error
+func (r *RouteRepository) Create(ctx context.Context, tx *gorm.DB, route *routeDomain.Route) error {
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+	err := db.Create(route).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}

--- a/internal/infrastructure/mysql/repository/schedule_repository.go
+++ b/internal/infrastructure/mysql/repository/schedule_repository.go
@@ -20,8 +20,14 @@ func NewScheduleRepository() scheduleDomain.ScheduleRepository {
 	}
 }
 
-func (r *ScheduleRepository) Create(ctx context.Context, schedule *scheduleDomain.Schedule) error {
-	err := r.db.Create(schedule).Error
+func (r *ScheduleRepository) Create(ctx context.Context, tx *gorm.DB, schedule *scheduleDomain.Schedule) error {
+	// トランザクションが渡されていない場合、通常のDB接続を使用
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+
+	err := db.Create(schedule).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}

--- a/internal/infrastructure/mysql/repository/visit_info_repository.go
+++ b/internal/infrastructure/mysql/repository/visit_info_repository.go
@@ -21,8 +21,13 @@ func NewVisitInfoRepository() visitInfoDomain.VisitInfoRepository {
 	}
 }
 
-func (r *VisitInfoRepository) Create(ctx context.Context, visitInfo *visitInfoDomain.VisitInfo) error {
-	err := r.db.Create(visitInfo).Error
+func (r *VisitInfoRepository) Create(ctx context.Context, tx *gorm.DB, visitInfo *visitInfoDomain.VisitInfo) error {
+	db := tx
+	if db == nil {
+		db = r.db
+	}
+
+	err := db.Create(visitInfo).Error
 	if err != nil {
 		return errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}

--- a/internal/usecase/schedule/create_schedule_use_case.go
+++ b/internal/usecase/schedule/create_schedule_use_case.go
@@ -8,7 +8,10 @@ import (
 	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
 	userDomain "api-buddy/domain/user"
 	visitInfoDomain "api-buddy/domain/visit_info"
+	"api-buddy/infrastructure/mysql/db"
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type CreateScheduleUseCase struct {
@@ -53,63 +56,72 @@ type CreateUseCaseInputDto struct {
 }
 
 func (uc *CreateScheduleUseCase) Run(ctx context.Context, input CreateUseCaseInputDto) (*scheduleDomain.Schedule, error) {
-	scheduleOptions := []scheduleDomain.ScheduleOption{}
-	// 予定の種類を取得
-	scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
-	if err != nil {
-		return nil, err
-	}
+	var schedule *scheduleDomain.Schedule
 
-	// スタッフを取得
-	staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
-	if err != nil {
-		return nil, err
-	}
+	err := db.WithTransaction(ctx, func(tx *gorm.DB) error {
+		// スケジュールオプションの初期化
+		scheduleOptions := []scheduleDomain.ScheduleOption{}
 
-	// 施設を取得
-	facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
-	if err != nil {
-		return nil, err
-	}
-
-	// 通常予定の場合
-	if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
-		scheduleOptions = append(scheduleOptions, scheduleDomain.WithTitle(*input.Title))
-	}
-
-	// 訪問情報がある場合
-	if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
-		// 訪問情報の作成
-		visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, *input.VisitInfo)
+		// 予定の種類を取得
+		scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		scheduleOptions = append(scheduleOptions, scheduleDomain.WithVisitInfo(visitInfo))
-	}
-
-	// 予定の説明がある場合
-	if input.Description != nil {
-		scheduleOptions = append(scheduleOptions, scheduleDomain.WithDescription(*input.Description))
-	}
-
-	// 繰り返し予定の変更予定の場合
-	if input.RecurringScheduleID != nil {
-		recurringSchedule, err := uc.recurringScheduleRepository.FindByID(ctx, *input.RecurringScheduleID)
+		// スタッフを取得
+		staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		scheduleOptions = append(scheduleOptions, scheduleDomain.WithRecurringSchedule(recurringSchedule))
-	}
 
-	// 予定のインスタンスを生成
-	schedule, err := scheduleDomain.NewSchedule(scheduleType, input.Date, input.StartTime, input.EndTime, staff, facility, scheduleOptions...)
-	if err != nil {
-		return nil, err
-	}
+		// 施設を取得
+		facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
+		if err != nil {
+			return err
+		}
 
-	// 予定を登録
-	err = uc.scheduleRepository.Create(ctx, schedule)
+		// 通常予定の場合
+		if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
+			scheduleOptions = append(scheduleOptions, scheduleDomain.WithTitle(*input.Title))
+		}
+
+		// 訪問情報がある場合
+		if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
+			visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, tx, *input.VisitInfo)
+			if err != nil {
+				return err
+			}
+			scheduleOptions = append(scheduleOptions, scheduleDomain.WithVisitInfo(visitInfo))
+		}
+
+		// 予定の説明がある場合
+		if input.Description != nil {
+			scheduleOptions = append(scheduleOptions, scheduleDomain.WithDescription(*input.Description))
+		}
+
+		// 繰り返し予定の変更予定の場合
+		if input.RecurringScheduleID != nil {
+			recurringSchedule, err := uc.recurringScheduleRepository.FindByID(ctx, *input.RecurringScheduleID)
+			if err != nil {
+				return err
+			}
+			scheduleOptions = append(scheduleOptions, scheduleDomain.WithRecurringSchedule(recurringSchedule))
+		}
+
+		// 予定のインスタンスを生成
+		schedule, err = scheduleDomain.NewSchedule(scheduleType, input.Date, input.StartTime, input.EndTime, staff, facility, scheduleOptions...)
+		if err != nil {
+			return err
+		}
+
+		// 予定を登録
+		if err := uc.scheduleRepository.Create(ctx, tx, schedule); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
+++ b/internal/usecase/schedule/recurring_schedule/create_recurring_schedule_use_case.go
@@ -8,7 +8,10 @@ import (
 	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
 	userDomain "api-buddy/domain/user"
 	visitInfoDomain "api-buddy/domain/visit_info"
+	"api-buddy/infrastructure/mysql/db"
 	"context"
+
+	"gorm.io/gorm"
 )
 
 type CreateRecurringScheduleUseCase struct {
@@ -61,101 +64,109 @@ type RecurringRuleModel struct {
 }
 
 func (uc *CreateRecurringScheduleUseCase) Run(ctx context.Context, input CreateRecurringScheduleUseCaseInputDto) (*recurringScheduleDomain.RecurringSchedule, error) {
-	recurringScheduleOptions := []recurringScheduleDomain.RecurringScheduleOption{}
-	// 予定の種類を取得
-	scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
-	if err != nil {
-		return nil, err
-	}
+	var recurringSchedule *recurringScheduleDomain.RecurringSchedule
 
-	// スタッフを取得
-	staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
-	if err != nil {
-		return nil, err
-	}
+	err := db.WithTransaction(ctx, func(tx *gorm.DB) error {
+		recurringScheduleOptions := []recurringScheduleDomain.RecurringScheduleOption{}
 
-	// 施設を取得
-	facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
-	if err != nil {
-		return nil, err
-	}
-
-	recurringScheduleRuleOptions := []recurringRuleDomain.RecurringRuleOption{}
-
-	// 曜日が指定されている場合
-	if input.RecurringRule.DaysOfWeek != nil {
-		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDaysOfWeek(*input.RecurringRule.DaysOfWeek))
-	}
-
-	// 月の日が指定されている場合
-	if input.RecurringRule.DayOfMonth != nil {
-		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDayOfMonth(*input.RecurringRule.DayOfMonth))
-	}
-
-	// 週の日が指定されている場合
-	if input.RecurringRule.WeekOfMonth != nil {
-		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithWeekOfMonth(*input.RecurringRule.WeekOfMonth))
-	}
-
-	// 終了日が指定されている場合
-	if input.RecurringRule.EndDate != nil {
-		recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithEndDate(*input.RecurringRule.EndDate))
-	}
-
-	// リクエストされた繰り返しルールを作成
-	recurringRule, err := recurringRuleDomain.NewRecurringRule(
-		input.RecurringRule.Frequency,
-		input.RecurringRule.StartDate,
-		recurringScheduleRuleOptions...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// 繰り返しルールの登録
-	err = uc.recurringRuleRepository.Create(ctx, recurringRule)
-	if err != nil {
-		return nil, err
-	}
-
-	// 通常予定の場合
-	if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
-		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithTitle(*input.Title))
-	}
-
-	// 訪問情報がある場合
-	if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
-		// 訪問情報の作成
-		visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, *input.VisitInfo)
+		// 予定の種類を取得
+		scheduleType, err := uc.scheduleTypeRepository.FindByID(ctx, input.ScheduleTypeID)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithVisitInfo(visitInfo))
-	}
+		// スタッフを取得
+		staff, err := uc.userRepository.FindByID(ctx, input.StaffID)
+		if err != nil {
+			return err
+		}
 
-	// 予定の説明がある場合
-	if input.Description != nil {
-		recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithDescription(*input.Description))
-	}
+		// 施設を取得
+		facility, err := uc.facilityRepository.FindByID(ctx, input.FacilityID)
+		if err != nil {
+			return err
+		}
 
-	// 繰り返し予定の作成
-	recurringSchedule, err := recurringScheduleDomain.NewRecurringSchedule(
-		recurringRule,
-		scheduleType,
-		input.Date,
-		input.StartTime,
-		input.EndTime,
-		staff,
-		facility,
-		recurringScheduleOptions...,
-	)
-	if err != nil {
-		return nil, err
-	}
+		recurringScheduleRuleOptions := []recurringRuleDomain.RecurringRuleOption{}
 
-	// 繰り返し予定を登録
-	err = uc.recurringScheduleRepository.Create(ctx, recurringSchedule)
+		// 曜日が指定されている場合
+		if input.RecurringRule.DaysOfWeek != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDaysOfWeek(*input.RecurringRule.DaysOfWeek))
+		}
+
+		// 月の日が指定されている場合
+		if input.RecurringRule.DayOfMonth != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithDayOfMonth(*input.RecurringRule.DayOfMonth))
+		}
+
+		// 週の日が指定されている場合
+		if input.RecurringRule.WeekOfMonth != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithWeekOfMonth(*input.RecurringRule.WeekOfMonth))
+		}
+
+		// 終了日が指定されている場合
+		if input.RecurringRule.EndDate != nil {
+			recurringScheduleRuleOptions = append(recurringScheduleRuleOptions, recurringRuleDomain.WithEndDate(*input.RecurringRule.EndDate))
+		}
+
+		// リクエストされた繰り返しルールを作成
+		recurringRule, err := recurringRuleDomain.NewRecurringRule(
+			input.RecurringRule.Frequency,
+			input.RecurringRule.StartDate,
+			recurringScheduleRuleOptions...,
+		)
+		if err != nil {
+			return err
+		}
+
+		// 繰り返しルールの登録
+		if err := uc.recurringRuleRepository.Create(ctx, tx, recurringRule); err != nil {
+			return err
+		}
+
+		// 通常予定の場合
+		if scheduleType.Name == scheduleTypeDomain.Normal && input.Title != nil {
+			recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithTitle(*input.Title))
+		}
+
+		// 訪問情報がある場合
+		if scheduleType.Name == scheduleTypeDomain.Visit && input.VisitInfo != nil {
+			visitInfo, err := uc.visitInfoService.CreateVisitInfo(ctx, tx, *input.VisitInfo)
+			if err != nil {
+				return err
+			}
+
+			recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithVisitInfo(visitInfo))
+		}
+
+		// 予定の説明がある場合
+		if input.Description != nil {
+			recurringScheduleOptions = append(recurringScheduleOptions, recurringScheduleDomain.WithDescription(*input.Description))
+		}
+
+		// 繰り返し予定の作成
+		recurringSchedule, err = recurringScheduleDomain.NewRecurringSchedule(
+			recurringRule,
+			scheduleType,
+			input.Date,
+			input.StartTime,
+			input.EndTime,
+			staff,
+			facility,
+			recurringScheduleOptions...,
+		)
+		if err != nil {
+			return err
+		}
+
+		// 繰り返し予定を登録
+		if err := uc.recurringScheduleRepository.Create(ctx, tx, recurringSchedule); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 関連：issue・Ticket
#30

## 概要
トランザクションが貼られていなかったため、訪問情報が登録された後に予定情報の登録で失敗すると、訪問情報のみがDBに保存される状態になっていた。
そのため、トランザクションを貼り、全ての処理が成功した場合にコミットするように修正

## 変更点
- トランザクションを管理するハンドラーを作成
- リポジトリ：作成のメソッドでトランザクションを外部から受け取れるように修正
  - 予定関連のリポジトリのみ


## 今後やること

- [ ] その他のリポジトリにもトランザクションを外部から受け取れる対応を追加する
- [ ] serviceとusercaseの処理のリファクタ
  - ドメイン層でgormのトランザクションを受け取るようなコードになっている
- [ ]

## 参考

(参考になった文献などがあれば貼り付ける)
