### PR TITLE
予定取得のエンドポイントを追加

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -793,6 +793,53 @@ const docTemplate = `{
             }
         },
         "/facilities/{facility_id}/schedules": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "施設に紐づく予定と繰り返し予定を全て取得する",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.ScheduleListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "consumes": [
                     "application/json"
@@ -1357,6 +1404,118 @@ const docTemplate = `{
                 }
             }
         },
+        "/schedules/recurring/{recurring_schedule_id}": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "単一の繰り返し予定を取得する",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "繰り返し予定ID",
+                        "name": "recurring_schedule_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.RecurringScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/schedules/{schedule_id}": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "単一の予定を取得する",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "予定ID",
+                        "name": "schedule_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.ScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/teams/{team_id}": {
             "get": {
                 "consumes": [
@@ -1562,6 +1721,28 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "api-buddy_domain_patient.PreferredGender": {
+            "type": "string",
+            "enum": [
+                "男性",
+                "女性"
+            ],
+            "x-enum-varnames": [
+                "Man",
+                "Woman"
+            ]
+        },
+        "api-buddy_domain_patient.PreferredTime": {
+            "type": "string",
+            "enum": [
+                "午後",
+                "午前"
+            ],
+            "x-enum-varnames": [
+                "PM",
+                "AM"
+            ]
         },
         "api-buddy_domain_policy.Policy": {
             "type": "object",
@@ -2011,10 +2192,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "preferred_gender": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredGender"
                 },
                 "preferred_time": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredTime"
                 },
                 "service_code_id": {
                     "type": "string"
@@ -2043,10 +2224,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "preferred_gender": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredGender"
                 },
                 "preferred_time": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredTime"
                 },
                 "service_code": {
                     "type": "string"
@@ -2072,10 +2253,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "preferred_gender": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredGender"
                 },
                 "preferred_time": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredTime"
                 }
             }
         },
@@ -2320,6 +2501,50 @@ const docTemplate = `{
                 }
             }
         },
+        "presentation_schedule.RecurringScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "exclusion_dates": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_over_time_work": {
+                    "type": "boolean"
+                },
+                "recurring_rule": {
+                    "$ref": "#/definitions/presentation_schedule.RecurringRuleResponseModel"
+                },
+                "schedule_type": {
+                    "type": "string"
+                },
+                "staff_name": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoResponseModel"
+                }
+            }
+        },
         "presentation_schedule.RouteRequestModel": {
             "type": "object",
             "required": [
@@ -2349,6 +2574,61 @@ const docTemplate = `{
                 },
                 "travel_time": {
                     "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.ScheduleListResponse": {
+            "type": "object",
+            "properties": {
+                "recurring_schedules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/presentation_schedule.RecurringScheduleResponse"
+                    }
+                },
+                "schedules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/presentation_schedule.ScheduleResponse"
+                    }
+                }
+            }
+        },
+        "presentation_schedule.ScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "cancel_reason": {
+                    "type": "string"
+                },
+                "date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_over_time_work": {
+                    "type": "boolean"
+                },
+                "schedule_type": {
+                    "type": "string"
+                },
+                "staff_name": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoResponseModel"
                 }
             }
         },

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -787,6 +787,53 @@
             }
         },
         "/facilities/{facility_id}/schedules": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "施設に紐づく予定と繰り返し予定を全て取得する",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.ScheduleListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "consumes": [
                     "application/json"
@@ -1351,6 +1398,118 @@
                 }
             }
         },
+        "/schedules/recurring/{recurring_schedule_id}": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "単一の繰り返し予定を取得する",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "繰り返し予定ID",
+                        "name": "recurring_schedule_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.RecurringScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/schedules/{schedule_id}": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Schedule"
+                ],
+                "summary": "単一の予定を取得する",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "施設ID",
+                        "name": "facility_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "予定ID",
+                        "name": "schedule_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/presentation_schedule.ScheduleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api-buddy_presentation_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/teams/{team_id}": {
             "get": {
                 "consumes": [
@@ -1556,6 +1715,28 @@
                     "type": "string"
                 }
             }
+        },
+        "api-buddy_domain_patient.PreferredGender": {
+            "type": "string",
+            "enum": [
+                "男性",
+                "女性"
+            ],
+            "x-enum-varnames": [
+                "Man",
+                "Woman"
+            ]
+        },
+        "api-buddy_domain_patient.PreferredTime": {
+            "type": "string",
+            "enum": [
+                "午後",
+                "午前"
+            ],
+            "x-enum-varnames": [
+                "PM",
+                "AM"
+            ]
         },
         "api-buddy_domain_policy.Policy": {
             "type": "object",
@@ -2005,10 +2186,10 @@
                     "type": "string"
                 },
                 "preferred_gender": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredGender"
                 },
                 "preferred_time": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredTime"
                 },
                 "service_code_id": {
                     "type": "string"
@@ -2037,10 +2218,10 @@
                     "type": "string"
                 },
                 "preferred_gender": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredGender"
                 },
                 "preferred_time": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredTime"
                 },
                 "service_code": {
                     "type": "string"
@@ -2066,10 +2247,10 @@
                     "type": "string"
                 },
                 "preferred_gender": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredGender"
                 },
                 "preferred_time": {
-                    "type": "string"
+                    "$ref": "#/definitions/api-buddy_domain_patient.PreferredTime"
                 }
             }
         },
@@ -2314,6 +2495,50 @@
                 }
             }
         },
+        "presentation_schedule.RecurringScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "exclusion_dates": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_over_time_work": {
+                    "type": "boolean"
+                },
+                "recurring_rule": {
+                    "$ref": "#/definitions/presentation_schedule.RecurringRuleResponseModel"
+                },
+                "schedule_type": {
+                    "type": "string"
+                },
+                "staff_name": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoResponseModel"
+                }
+            }
+        },
         "presentation_schedule.RouteRequestModel": {
             "type": "object",
             "required": [
@@ -2343,6 +2568,61 @@
                 },
                 "travel_time": {
                     "type": "integer"
+                }
+            }
+        },
+        "presentation_schedule.ScheduleListResponse": {
+            "type": "object",
+            "properties": {
+                "recurring_schedules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/presentation_schedule.RecurringScheduleResponse"
+                    }
+                },
+                "schedules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/presentation_schedule.ScheduleResponse"
+                    }
+                }
+            }
+        },
+        "presentation_schedule.ScheduleResponse": {
+            "type": "object",
+            "properties": {
+                "cancel_reason": {
+                    "type": "string"
+                },
+                "date": {
+                    "$ref": "#/definitions/api-buddy_domain_common.Date"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_over_time_work": {
+                    "type": "boolean"
+                },
+                "schedule_type": {
+                    "type": "string"
+                },
+                "staff_name": {
+                    "type": "string"
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "visit_info": {
+                    "$ref": "#/definitions/presentation_schedule.VisitInfoResponseModel"
                 }
             }
         },

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -5,6 +5,22 @@ definitions:
       time.Time:
         type: string
     type: object
+  api-buddy_domain_patient.PreferredGender:
+    enum:
+    - 男性
+    - 女性
+    type: string
+    x-enum-varnames:
+    - Man
+    - Woman
+  api-buddy_domain_patient.PreferredTime:
+    enum:
+    - 午後
+    - 午前
+    type: string
+    x-enum-varnames:
+    - PM
+    - AM
   api-buddy_domain_policy.Policy:
     properties:
       created_at:
@@ -298,9 +314,9 @@ definitions:
       name:
         type: string
       preferred_gender:
-        type: string
+        $ref: '#/definitions/api-buddy_domain_patient.PreferredGender'
       preferred_time:
-        type: string
+        $ref: '#/definitions/api-buddy_domain_patient.PreferredTime'
       service_code_id:
         type: string
     required:
@@ -327,9 +343,9 @@ definitions:
       name:
         type: string
       preferred_gender:
-        type: string
+        $ref: '#/definitions/api-buddy_domain_patient.PreferredGender'
       preferred_time:
-        type: string
+        $ref: '#/definitions/api-buddy_domain_patient.PreferredTime'
       service_code:
         type: string
     type: object
@@ -346,9 +362,9 @@ definitions:
       name:
         type: string
       preferred_gender:
-        type: string
+        $ref: '#/definitions/api-buddy_domain_patient.PreferredGender'
       preferred_time:
-        type: string
+        $ref: '#/definitions/api-buddy_domain_patient.PreferredTime'
     type: object
   presentation_policy.CreatePolicyRequest:
     properties:
@@ -512,6 +528,35 @@ definitions:
       week_of_month:
         type: integer
     type: object
+  presentation_schedule.RecurringScheduleResponse:
+    properties:
+      date:
+        $ref: '#/definitions/api-buddy_domain_common.Date'
+      description:
+        type: string
+      end_time:
+        type: string
+      exclusion_dates:
+        items:
+          type: integer
+        type: array
+      id:
+        type: string
+      is_over_time_work:
+        type: boolean
+      recurring_rule:
+        $ref: '#/definitions/presentation_schedule.RecurringRuleResponseModel'
+      schedule_type:
+        type: string
+      staff_name:
+        type: string
+      start_time:
+        type: string
+      title:
+        type: string
+      visit_info:
+        $ref: '#/definitions/presentation_schedule.VisitInfoResponseModel'
+    type: object
   presentation_schedule.RouteRequestModel:
     properties:
       destination_id:
@@ -532,6 +577,42 @@ definitions:
         type: string
       travel_time:
         type: integer
+    type: object
+  presentation_schedule.ScheduleListResponse:
+    properties:
+      recurring_schedules:
+        items:
+          $ref: '#/definitions/presentation_schedule.RecurringScheduleResponse'
+        type: array
+      schedules:
+        items:
+          $ref: '#/definitions/presentation_schedule.ScheduleResponse'
+        type: array
+    type: object
+  presentation_schedule.ScheduleResponse:
+    properties:
+      cancel_reason:
+        type: string
+      date:
+        $ref: '#/definitions/api-buddy_domain_common.Date'
+      description:
+        type: string
+      end_time:
+        type: string
+      id:
+        type: string
+      is_over_time_work:
+        type: boolean
+      schedule_type:
+        type: string
+      staff_name:
+        type: string
+      start_time:
+        type: string
+      title:
+        type: string
+      visit_info:
+        $ref: '#/definitions/presentation_schedule.VisitInfoResponseModel'
     type: object
   presentation_schedule.VisitCategoryResponseModel:
     properties:
@@ -1172,6 +1253,37 @@ paths:
       tags:
       - Position
   /facilities/{facility_id}/schedules:
+    get:
+      consumes:
+      - application/json
+      parameters:
+      - description: 施設ID
+        in: path
+        name: facility_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/presentation_schedule.ScheduleListResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+      summary: 施設に紐づく予定と繰り返し予定を全て取得する
+      tags:
+      - Schedule
     post:
       consumes:
       - application/json
@@ -1540,6 +1652,80 @@ paths:
       summary: 単一の役職を取得する
       tags:
       - Position
+  /schedules/{schedule_id}:
+    get:
+      consumes:
+      - application/json
+      parameters:
+      - description: 施設ID
+        in: path
+        name: facility_id
+        required: true
+        type: string
+      - description: 予定ID
+        in: path
+        name: schedule_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/presentation_schedule.ScheduleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+      summary: 単一の予定を取得する
+      tags:
+      - Schedule
+  /schedules/recurring/{recurring_schedule_id}:
+    get:
+      consumes:
+      - application/json
+      parameters:
+      - description: 施設ID
+        in: path
+        name: facility_id
+        required: true
+        type: string
+      - description: 繰り返し予定ID
+        in: path
+        name: recurring_schedule_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/presentation_schedule.RecurringScheduleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api-buddy_presentation_common.ErrorResponse'
+      summary: 単一の繰り返し予定を取得する
+      tags:
+      - Schedule
   /teams/{team_id}:
     get:
       consumes:

--- a/internal/infrastructure/mysql/db/sql_handler.go
+++ b/internal/infrastructure/mysql/db/sql_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Fukuemon/go-pkg/query"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
@@ -53,4 +54,42 @@ func NewSQLHandler(cnf config.DBConfig) *SQLHandler {
 	db.Logger.LogMode(4)
 	sqlHandler.DB = db
 	return sqlHandler
+}
+
+func ApplyFiltersAndSort(dbQuery *gorm.DB, filters []query.Filter, sort query.SortOption, mappings map[string]query.RelationMapping) *gorm.DB {
+	q := query.NewQuery()
+
+	// フィルタを適用
+	for _, filter := range filters {
+		filter.Apply(q)
+	}
+
+	// リレーションに基づくフィルタリング
+	for _, mapping := range mappings {
+		if value, exists := q.Filters[mapping.FilterField]; exists {
+			dbQuery = dbQuery.Joins("JOIN "+mapping.TableName+" ON "+mapping.JoinKey).
+				Where(mapping.TableName+"."+mapping.FilterField+" = ?", value)
+		}
+	}
+
+	// 単純なフィルタリング
+	for key, value := range q.Filters {
+		if _, isRelationField := mappings[key]; !isRelationField {
+			dbQuery = dbQuery.Where(key+" = ?", value)
+		}
+	}
+
+	// ソートオプションの適用
+	if sort.Field != "" {
+		if mapping, exists := mappings[sort.Field]; exists {
+			dbQuery = dbQuery.Joins("JOIN " + mapping.TableName + " ON " + mapping.JoinKey).
+				Order(mapping.TableName + "." + mapping.FilterField + " " + sort.Order)
+		} else {
+			dbQuery = dbQuery.Order(sort.Field + " " + sort.Order)
+		}
+	} else {
+		dbQuery = dbQuery.Order("created_at DESC") // デフォルトのソート条件
+	}
+
+	return dbQuery
 }

--- a/internal/infrastructure/mysql/repository/recurring_schedule_repository.go
+++ b/internal/infrastructure/mysql/repository/recurring_schedule_repository.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"api-buddy/domain/common"
 	errorDomain "api-buddy/domain/error"
 	recurringScheduleDomain "api-buddy/domain/schedule/recurring_schedule"
 	"api-buddy/infrastructure/mysql/db"
@@ -34,42 +33,27 @@ func (r *RecurringScheduleRepository) Create(ctx context.Context, tx *gorm.DB, r
 }
 
 func (r *RecurringScheduleRepository) FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*recurringScheduleDomain.RecurringSchedule, error) {
-	q := query.NewQuery()
+	dbQuery := r.db.Table("recurring_schedules") // 明示的にテーブルを指定
 
-	// Queryオブジェクトにフィルターを適用
-	for _, filter := range filters {
-		filter.Apply(q)
-	}
-
-	dbQuery := r.db
-
-	for _, mapping := range recurringScheduleDomain.RecurringScheduleRelationMappings {
-		if value, exists := q.Filters[mapping.FilterField]; exists {
-			dbQuery = dbQuery.Joins("JOIN "+mapping.TableName+" ON "+mapping.JoinKey).
-				Where(mapping.FilterField+" = ?", value)
-		}
-	}
-
-	for key, value := range q.Filters {
-		if _, isRelationField := recurringScheduleDomain.RecurringScheduleRelationMappings[key]; !isRelationField {
-			dbQuery = dbQuery.Where(key, value)
-		}
-	}
-
-	if sort.Field != "" {
-		if mapping, exists := recurringScheduleDomain.RecurringScheduleRelationMappings[sort.Field]; exists {
-			dbQuery = dbQuery.Joins("JOIN " + mapping.TableName + " ON " + mapping.JoinKey).
-				Order(mapping.FilterField + " " + sort.Order)
-		} else {
-			dbQuery = dbQuery.Order(sort.Field + " " + sort.Order)
-		}
-	} else {
-		dbQuery = dbQuery.Order(common.UpdatedAt + " " + query.DESC)
-	}
+	// フィルタとソートを適用
+	dbQuery = db.ApplyFiltersAndSort(dbQuery, filters, sort, recurringScheduleDomain.RecurringScheduleRelationMappings)
 
 	var recurringSchedules []*recurringScheduleDomain.RecurringSchedule
-	err := dbQuery.Preload("Facility").Preload("RecurringRule").Preload("VisitInfo").Preload("ScheduleType").Preload("Staff").
-		Where("facility_id = ?", facility_id).Find(&recurringSchedules).Error
+	err := dbQuery.
+		Preload("Facility").
+		Preload("VisitInfo").
+		Preload("VisitInfo.Patient").
+		Preload("VisitInfo.AssignedStaff").
+		Preload("VisitInfo.Companion").
+		Preload("VisitInfo.Route").
+		Preload("VisitInfo.Route.Address").
+		Preload("VisitInfo.Route.Destination").
+		Preload("VisitInfo.ServiceCode").
+		Preload("VisitInfo.VisitCategories").
+		Preload("ScheduleType").
+		Preload("Staff").
+		Preload("RecurringRule").
+		Where("recurring_schedules.facility_id = ?", facility_id).Find(&recurringSchedules).Error
 	if err != nil {
 		return nil, errorDomain.WrapError(errorDomain.GeneralDBError, err)
 	}
@@ -78,7 +62,20 @@ func (r *RecurringScheduleRepository) FindByFacilityID(ctx context.Context, faci
 
 func (r *RecurringScheduleRepository) FindByID(ctx context.Context, id string) (*recurringScheduleDomain.RecurringSchedule, error) {
 	var recurringSchedule *recurringScheduleDomain.RecurringSchedule
-	err := r.db.Preload("Facility").Preload("RecurringRule").Preload("VisitInfo").Preload("ScheduleType").Preload("Staff").
+	err := r.db.
+		Preload("Facility").
+		Preload("VisitInfo").
+		Preload("VisitInfo.Patient").
+		Preload("VisitInfo.AssignedStaff").
+		Preload("VisitInfo.Companion").
+		Preload("VisitInfo.Route").
+		Preload("VisitInfo.Route.Address").
+		Preload("VisitInfo.Route.Destination").
+		Preload("VisitInfo.ServiceCode").
+		Preload("VisitInfo.VisitCategories").
+		Preload("ScheduleType").
+		Preload("Staff").
+		Preload("RecurringRule").
 		Where("id = ?", id).First(&recurringSchedule).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {

--- a/internal/infrastructure/mysql/repository/schedule_repository.go
+++ b/internal/infrastructure/mysql/repository/schedule_repository.go
@@ -35,46 +35,28 @@ func (r *ScheduleRepository) Create(ctx context.Context, tx *gorm.DB, schedule *
 }
 
 func (r *ScheduleRepository) FindByFacilityID(ctx context.Context, facility_id string, filters []query.Filter, sort query.SortOption) ([]*scheduleDomain.Schedule, error) {
-	// Queryオブジェクトを初期化
-	q := query.NewQuery()
+	dbQuery := r.db.Table("schedules") // 明示的にテーブルを指定
 
-	// Queryオブジェクトにフィルターを適用
-	for _, filter := range filters {
-		filter.Apply(q)
-	}
-
-	dbQuery := r.db
-
-	// リレーションテーブルに基づいたフィルタリングのQueryを適用
-	for _, mapping := range scheduleDomain.ScheduleRelationMappings {
-		if value, exists := q.Filters[mapping.FilterField]; exists {
-			dbQuery = dbQuery.Joins("JOIN "+mapping.TableName+" ON "+mapping.JoinKey).
-				Where(mapping.FilterField+" = ?", value)
-		}
-	}
-
-	// 残りのフィルタリング（`schedules` テーブルに対するフィルター）を適用
-	for key, value := range q.Filters {
-		if _, isRelationField := scheduleDomain.ScheduleRelationMappings[key]; !isRelationField {
-			dbQuery = dbQuery.Where(key, value)
-		}
-	}
-
-	// ソートオプションの適用
-	if sort.Field != "" {
-		if mapping, exists := scheduleDomain.ScheduleRelationMappings[sort.Field]; exists {
-			dbQuery = dbQuery.Joins("JOIN " + mapping.TableName + " ON " + mapping.JoinKey).
-				Order(mapping.TableName + "." + sort.Field + " " + sort.Order)
-		} else {
-			dbQuery = dbQuery.Order(sort.Field + " " + sort.Order)
-		}
-	} else {
-		dbQuery = dbQuery.Order(sort.Field + " " + sort.Order)
-	}
+	// フィルタとソートを適用
+	dbQuery = db.ApplyFiltersAndSort(dbQuery, filters, sort, scheduleDomain.ScheduleRelationMappings)
 
 	var schedules []*scheduleDomain.Schedule
-	err := dbQuery.Preload("Facility").Preload("RecurringSchedule").Preload("VisitInfo").Preload("ScheduleType").Preload("Staff").Preload("ScheduleCancel").
-		Find(&schedules).Error
+	err := dbQuery.
+		Preload("Facility").
+		Preload("RecurringSchedule").
+		Preload("VisitInfo").
+		Preload("VisitInfo.Patient").
+		Preload("VisitInfo.AssignedStaff").
+		Preload("VisitInfo.Companion").
+		Preload("VisitInfo.Route").
+		Preload("VisitInfo.Route.Address").
+		Preload("VisitInfo.Route.Destination").
+		Preload("VisitInfo.ServiceCode").
+		Preload("VisitInfo.VisitCategories").
+		Preload("ScheduleType").
+		Preload("Staff").
+		Preload("ScheduleCancel").
+		Where("schedules.facility_id = ?", facility_id).Find(&schedules).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
@@ -86,7 +68,21 @@ func (r *ScheduleRepository) FindByFacilityID(ctx context.Context, facility_id s
 
 func (r *ScheduleRepository) FindByID(ctx context.Context, id string) (*scheduleDomain.Schedule, error) {
 	var schedule *scheduleDomain.Schedule
-	err := r.db.Preload("Facility").Preload("RecurringSchedule").Preload("VisitInfo").Preload("ScheduleType").Preload("Staff").Preload("ScheduleCancel").
+	err := r.db.
+		Preload("Facility").
+		Preload("RecurringSchedule").
+		Preload("VisitInfo").
+		Preload("VisitInfo.Patient").
+		Preload("VisitInfo.AssignedStaff").
+		Preload("VisitInfo.Companion").
+		Preload("VisitInfo.Route").
+		Preload("VisitInfo.Route.Address").
+		Preload("VisitInfo.Route.Destination").
+		Preload("VisitInfo.ServiceCode").
+		Preload("VisitInfo.VisitCategories").
+		Preload("ScheduleType").
+		Preload("Staff").
+		Preload("ScheduleCancel").
 		Where("id = ?", id).First(&schedule).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {

--- a/internal/presentation/schedule/handler.go
+++ b/internal/presentation/schedule/handler.go
@@ -18,17 +18,23 @@ type handler struct {
 	createScheduleUseCase          *schedule.CreateScheduleUseCase
 	createRecurringScheduleUseCase *recurringSchedule.CreateRecurringScheduleUseCase
 	fetchScheduleUseCase           *schedule.FetchScheduleUseCase
+	findScheduleUseCase            *schedule.FindScheduleUseCase
+	findREcurringScheduleUseCase   *recurringSchedule.FindRecurringScheduleUseCase
 }
 
 func NewHandler(
 	createScheduleUseCase *schedule.CreateScheduleUseCase,
 	createRecurringScheduleUseCase *recurringSchedule.CreateRecurringScheduleUseCase,
 	fetchScheduleUseCase *schedule.FetchScheduleUseCase,
+	findScheduleUseCase *schedule.FindScheduleUseCase,
+	findRecurringScheduleUseCase *recurringSchedule.FindRecurringScheduleUseCase,
 ) *handler {
 	return &handler{
 		createScheduleUseCase:          createScheduleUseCase,
 		createRecurringScheduleUseCase: createRecurringScheduleUseCase,
 		fetchScheduleUseCase:           fetchScheduleUseCase,
+		findScheduleUseCase:            findScheduleUseCase,
+		findREcurringScheduleUseCase:   findRecurringScheduleUseCase,
 	}
 }
 
@@ -438,6 +444,174 @@ func (h *handler) FetchByFacilityId(ctx *gin.Context) {
 	}
 
 	settings.ReturnStatusOK(ctx, schedules)
+}
+
+// FindSchedule godoc
+// @Summary 単一の予定を取得する
+// @Tags Schedule
+// @Accept json
+// @Produce json
+// @Param facility_id path string true "施設ID"
+// @Param schedule_id path string true "予定ID"
+// @Success 200 {object} ScheduleResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /schedules/{schedule_id} [get]
+func (h *handler) FindScheduleByID(ctx *gin.Context) {
+	scheduleID := pathValidator.Param(ctx, "schedule_id", "required", "ulid")
+	err := scheduleID.ParamValidate()
+	if err != nil {
+		ctx.Error(errorDomain.ValidationError(err))
+		return
+	}
+
+	output, err := h.findScheduleUseCase.Run(ctx, scheduleID.ParamValue)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	response := ScheduleResponse{
+		ID:             output.ID,
+		ScheduleType:   string(*output.ScheduleType),
+		Date:           output.Date,
+		StartTime:      output.StartTime,
+		EndTime:        output.EndTime,
+		IsOverTimeWork: output.IsOverTimeWork,
+		StaffName:      output.StaffName,
+		VisitInfo: func() *VisitInfoResponseModel {
+			if output.VisitInfo == nil {
+				return nil
+			}
+			return &VisitInfoResponseModel{
+				PatientName:       output.VisitInfo.Patient,
+				AssignedStaffName: output.VisitInfo.AssignedStaff,
+				CompanionName:     output.VisitInfo.Companion,
+				Route: func() *RouteResponseModel {
+					if output.VisitInfo.Route != nil {
+						return &RouteResponseModel{
+							TravelTime:    output.VisitInfo.Route.TravelTime,
+							AddressID:     output.VisitInfo.Route.Address,
+							DestinationID: output.VisitInfo.Route.Destination,
+						}
+					}
+					return nil
+				}(),
+				ServiceCode: output.VisitInfo.ServiceCode,
+				VisitCategories: func() []VisitCategoryResponseModel {
+					var categories []VisitCategoryResponseModel
+					if output.VisitInfo.VisitCategories != nil {
+						for _, category := range output.VisitInfo.VisitCategories {
+							categories = append(categories, VisitCategoryResponseModel{
+								ID:   category.ID,
+								Name: category.Name,
+							})
+						}
+					}
+					return categories
+				}(),
+			}
+		}(),
+		Title:       *output.Title,
+		Description: *output.Description,
+		CancelReason: func() string {
+			if output.CancelReason != nil {
+				return *output.CancelReason
+			}
+			return ""
+		}(),
+	}
+
+	settings.ReturnStatusOK(ctx, response)
+}
+
+// FindRecurringSchedule godoc
+// @Summary 単一の繰り返し予定を取得する
+// @Tags Schedule
+// @Accept json
+// @Produce json
+// @Param facility_id path string true "施設ID"
+// @Param recurring_schedule_id path string true "繰り返し予定ID"
+// @Success 200 {object} RecurringScheduleResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /schedules/recurring/{recurring_schedule_id} [get]
+func (h *handler) FindRecurringScheduleByID(ctx *gin.Context) {
+	recurringScheduleID := pathValidator.Param(ctx, "recurring_schedule_id", "required", "ulid")
+	err := recurringScheduleID.ParamValidate()
+	if err != nil {
+		ctx.Error(errorDomain.ValidationError(err))
+		return
+	}
+
+	output, err := h.findREcurringScheduleUseCase.Run(ctx, recurringScheduleID.ParamValue)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	response := RecurringScheduleResponse{
+		ID: output.ID,
+		RecurringRule: &RecurringRuleResponseModel{
+			Frequency:   output.RecurringRule.Frequency,
+			DaysOfWeek:  output.RecurringRule.DayOfWeek,
+			DayOfMonth:  output.RecurringRule.DayOfMonth,
+			WeekOfMonth: output.RecurringRule.WeekOfMonth,
+			StartDate:   output.RecurringRule.StartDate,
+			EndDate:     output.RecurringRule.EndDate,
+		},
+		ScheduleType:   string(*output.ScheduleType),
+		Date:           output.Date,
+		StartTime:      output.StartTime,
+		EndTime:        output.EndTime,
+		IsOverTimeWork: output.IsOverTimeWork,
+		StaffName:      output.StaffName,
+		VisitInfo: func() *VisitInfoResponseModel {
+			if output.VisitInfo == nil {
+				return nil
+			}
+			return &VisitInfoResponseModel{
+				PatientName:       output.VisitInfo.Patient,
+				AssignedStaffName: output.VisitInfo.AssignedStaff,
+				CompanionName:     output.VisitInfo.Companion,
+				Route: func() *RouteResponseModel {
+					if output.VisitInfo.Route != nil {
+						return &RouteResponseModel{
+							TravelTime:    output.VisitInfo.Route.TravelTime,
+							AddressID:     output.VisitInfo.Route.Address,
+							DestinationID: output.VisitInfo.Route.Destination,
+						}
+					}
+					return nil
+				}(),
+				ServiceCode: output.VisitInfo.ServiceCode,
+				VisitCategories: func() []VisitCategoryResponseModel {
+					var categories []VisitCategoryResponseModel
+					if output.VisitInfo.VisitCategories != nil {
+						for _, category := range output.VisitInfo.VisitCategories {
+							categories = append(categories, VisitCategoryResponseModel{
+								ID:   category.ID,
+								Name: category.Name,
+							})
+						}
+					}
+					return categories
+				}(),
+			}
+		}(),
+		Title:       *output.Title,
+		Description: *output.Description,
+		ExclusionDates: func() []int {
+			if output.ExclusionDates == nil {
+				return nil
+			}
+			return *output.ExclusionDates
+		}(),
+	}
+
+	settings.ReturnStatusOK(ctx, response)
 }
 
 // CreateChangeRecurringSchedule godoc

--- a/internal/presentation/schedule/handler.go
+++ b/internal/presentation/schedule/handler.go
@@ -10,21 +10,25 @@ import (
 	recurringSchedule "api-buddy/usecase/schedule/recurring_schedule"
 
 	"github.com/Fukuemon/go-pkg/validator"
+	pathValidator "github.com/Fukuemon/go-pkg/validator/gin"
 	"github.com/gin-gonic/gin"
 )
 
 type handler struct {
 	createScheduleUseCase          *schedule.CreateScheduleUseCase
 	createRecurringScheduleUseCase *recurringSchedule.CreateRecurringScheduleUseCase
+	fetchScheduleUseCase           *schedule.FetchScheduleUseCase
 }
 
 func NewHandler(
 	createScheduleUseCase *schedule.CreateScheduleUseCase,
 	createRecurringScheduleUseCase *recurringSchedule.CreateRecurringScheduleUseCase,
+	fetchScheduleUseCase *schedule.FetchScheduleUseCase,
 ) *handler {
 	return &handler{
 		createScheduleUseCase:          createScheduleUseCase,
 		createRecurringScheduleUseCase: createRecurringScheduleUseCase,
+		fetchScheduleUseCase:           fetchScheduleUseCase,
 	}
 }
 
@@ -278,10 +282,163 @@ func (h *handler) CreateRecurringSchedule(ctx *gin.Context) {
 	settings.ReturnStatusCreated(ctx, response)
 }
 
-// GetSchedule godoc
-// @Summary 予定を取得する
+// GetSchedule swagger
+// @Summary 施設に紐づく予定と繰り返し予定を全て取得する
 // @Tags Schedule
 // @Accept json
+// @Produce json
+// @Param facility_id path string true "施設ID"
+// @Success 200 {object} ScheduleListResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse
+// @Failure 500 {object} common.ErrorResponse
+// @Router /facilities/{facility_id}/schedules [get]
+func (h *handler) FetchByFacilityId(ctx *gin.Context) {
+	facilityID := pathValidator.Param(ctx, "facility_id", "required", "ulid")
+	err := facilityID.ParamValidate()
+	if err != nil {
+		ctx.Error(errorDomain.ValidationError(err))
+		return
+	}
+
+	scheduleType := ctx.Query("schedule_type")
+	sortField := ctx.Query("sort_field")
+	sortOrder := ctx.Query("sort_order")
+
+	input := schedule.FetchScheduleUseCaseInputDto{
+		ScheduleType: scheduleType,
+		SortField:    sortField,
+		SortOrder:    sortOrder,
+	}
+
+	output, err := h.fetchScheduleUseCase.Run(ctx, facilityID.ParamValue, input)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	schedules := ScheduleListResponse{
+		Schedules: func() []*ScheduleResponse {
+			var schedules []*ScheduleResponse
+			for _, schedule := range output.Schedules {
+				schedules = append(schedules, &ScheduleResponse{
+					ID:           schedule.ID,
+					ScheduleType: string(schedule.ScheduleType),
+					Date:         schedule.Date,
+					StartTime:    schedule.StartTime,
+					EndTime:      schedule.EndTime,
+					StaffName:    schedule.StaffName,
+					VisitInfo: func() *VisitInfoResponseModel {
+						if schedule.VisitInfo == nil {
+							return nil
+						}
+						return &VisitInfoResponseModel{
+							PatientName:       schedule.VisitInfo.Patient,
+							AssignedStaffName: schedule.VisitInfo.AssignedStaff,
+							CompanionName:     schedule.VisitInfo.Companion,
+							Route: func() *RouteResponseModel {
+								if schedule.VisitInfo.Route != nil {
+									return &RouteResponseModel{
+										TravelTime:    schedule.VisitInfo.Route.TravelTime,
+										AddressID:     schedule.VisitInfo.Route.Address,
+										DestinationID: schedule.VisitInfo.Route.Destination,
+									}
+								}
+								return nil
+							}(),
+							ServiceCode: schedule.VisitInfo.ServiceCode,
+							VisitCategories: func() []VisitCategoryResponseModel {
+								var categories []VisitCategoryResponseModel
+								if schedule.VisitInfo.VisitCategories != nil {
+									for _, category := range schedule.VisitInfo.VisitCategories {
+										categories = append(categories, VisitCategoryResponseModel{
+											ID:   category.ID,
+											Name: category.Name,
+										})
+									}
+								}
+								return categories
+							}(),
+						}
+					}(),
+					Title:       schedule.Title,
+					Description: schedule.Description,
+				})
+			}
+			return schedules
+		}(),
+		RecurringSchedules: func() []*RecurringScheduleResponse {
+			var recurringSchedules []*RecurringScheduleResponse
+			for _, recurringSchedule := range output.RecurringSchedules {
+				recurringSchedules = append(recurringSchedules, &RecurringScheduleResponse{
+					ID: recurringSchedule.ID,
+					RecurringRule: func() *RecurringRuleResponseModel {
+						if recurringSchedule.RecurringRule != nil {
+							return &RecurringRuleResponseModel{
+								Frequency:   recurringSchedule.RecurringRule.Frequency,
+								DaysOfWeek:  recurringSchedule.RecurringRule.DayOfWeek,
+								DayOfMonth:  recurringSchedule.RecurringRule.DayOfMonth,
+								WeekOfMonth: recurringSchedule.RecurringRule.WeekOfMonth,
+								StartDate:   recurringSchedule.RecurringRule.StartDate,
+								EndDate:     recurringSchedule.RecurringRule.EndDate,
+							}
+						}
+						return nil
+					}(),
+					ScheduleType: string(recurringSchedule.ScheduleType),
+					Date:         recurringSchedule.Date,
+					StartTime:    recurringSchedule.StartTime,
+					EndTime:      recurringSchedule.EndTime,
+					StaffName:    recurringSchedule.StaffName,
+					VisitInfo: func() *VisitInfoResponseModel {
+						if recurringSchedule.VisitInfo == nil {
+							return nil
+						}
+						return &VisitInfoResponseModel{
+							PatientName:       recurringSchedule.VisitInfo.Patient,
+							AssignedStaffName: recurringSchedule.VisitInfo.AssignedStaff,
+							CompanionName:     recurringSchedule.VisitInfo.Companion,
+							Route: func() *RouteResponseModel {
+								if recurringSchedule.VisitInfo.Route != nil {
+									return &RouteResponseModel{
+										TravelTime:    recurringSchedule.VisitInfo.Route.TravelTime,
+										AddressID:     recurringSchedule.VisitInfo.Route.Address,
+										DestinationID: recurringSchedule.VisitInfo.Route.Destination,
+									}
+								}
+								return nil
+							}(),
+							ServiceCode: recurringSchedule.VisitInfo.ServiceCode,
+							VisitCategories: func() []VisitCategoryResponseModel {
+								var categories []VisitCategoryResponseModel
+								if recurringSchedule.VisitInfo.VisitCategories != nil {
+									for _, category := range recurringSchedule.VisitInfo.VisitCategories {
+										categories = append(categories, VisitCategoryResponseModel{
+											ID:   category.ID,
+											Name: category.Name,
+										})
+									}
+								}
+								return categories
+							}(),
+						}
+					}(),
+					Title:       recurringSchedule.Title,
+					Description: recurringSchedule.Description,
+					ExclusionDates: func() []int {
+						if recurringSchedule.ExclusionDates == nil {
+							return nil
+						}
+						return *recurringSchedule.ExclusionDates
+					}(),
+				})
+			}
+			return recurringSchedules
+		}(),
+	}
+
+	settings.ReturnStatusOK(ctx, schedules)
+}
 
 // CreateChangeRecurringSchedule godoc
 // @Summary 繰り返し予定を変更する

--- a/internal/presentation/schedule/response.go
+++ b/internal/presentation/schedule/response.go
@@ -19,6 +19,40 @@ type CreateScheduleResponse struct {
 	RecurringScheduleID string                  `json:"recurring_schedule_id"`
 }
 
+type ScheduleResponse struct {
+	ID             string                  `json:"id"`
+	ScheduleType   string                  `json:"schedule_type"`
+	Date           common.Date             `json:"date"`
+	StartTime      common.Time             `json:"start_time"`
+	EndTime        common.Time             `json:"end_time"`
+	IsOverTimeWork bool                    `json:"is_over_time_work"`
+	StaffName      string                  `json:"staff_name"`
+	VisitInfo      *VisitInfoResponseModel `json:"visit_info"`
+	Title          string                  `json:"title"`
+	Description    string                  `json:"description"`
+	CancelReason   string                  `json:"cancel_reason"`
+}
+
+type RecurringScheduleResponse struct {
+	ID             string                      `json:"id"`
+	RecurringRule  *RecurringRuleResponseModel `json:"recurring_rule"`
+	ScheduleType   string                      `json:"schedule_type"`
+	Date           common.Date                 `json:"date"`
+	StartTime      common.Time                 `json:"start_time"`
+	EndTime        common.Time                 `json:"end_time"`
+	IsOverTimeWork bool                        `json:"is_over_time_work"`
+	StaffName      string                      `json:"staff_name"`
+	VisitInfo      *VisitInfoResponseModel     `json:"visit_info"`
+	Title          string                      `json:"title"`
+	Description    string                      `json:"description"`
+	ExclusionDates common.JSONSlice[int]       `json:"exclusion_dates"`
+}
+
+type ScheduleListResponse struct {
+	Schedules          []*ScheduleResponse          `json:"schedules"`
+	RecurringSchedules []*RecurringScheduleResponse `json:"recurring_schedules"`
+}
+
 type VisitInfoResponseModel struct {
 	ID                string                       `json:"id"`
 	PatientName       string                       `json:"patient_name"`

--- a/internal/server/route/route.go
+++ b/internal/server/route/route.go
@@ -210,9 +210,11 @@ func scheduleRoute(r *gin.RouterGroup) {
 	h := schedulePre.NewHandler(
 		scheduleUse.NewCreateScheduleUseCase(scheduleRepository, facilityRepository, scheduleTypeRepository, userRepository, recurringScheduleRepository, visitInfoService),
 		recurringScheduleUse.NewCreateRecurringScheduleUseCase(recurringRuleRepository, facilityRepository, scheduleTypeRepository, userRepository, recurringScheduleRepository, visitInfoService),
+		scheduleUse.NewFetchScheduleUseCase(scheduleRepository, recurringScheduleRepository),
 	)
 	group := r.Group("/facilities/:facility_id/schedules")
 	group.POST("", h.CreateSchedule)
+	group.GET("", h.FetchByFacilityId)
 
 	group = r.Group("/facilities/:facility_id/schedules/recurring")
 	group.POST("", h.CreateRecurringSchedule)

--- a/internal/server/route/route.go
+++ b/internal/server/route/route.go
@@ -211,6 +211,8 @@ func scheduleRoute(r *gin.RouterGroup) {
 		scheduleUse.NewCreateScheduleUseCase(scheduleRepository, facilityRepository, scheduleTypeRepository, userRepository, recurringScheduleRepository, visitInfoService),
 		recurringScheduleUse.NewCreateRecurringScheduleUseCase(recurringRuleRepository, facilityRepository, scheduleTypeRepository, userRepository, recurringScheduleRepository, visitInfoService),
 		scheduleUse.NewFetchScheduleUseCase(scheduleRepository, recurringScheduleRepository),
+		scheduleUse.NewFindScheduleUseCase(scheduleRepository),
+		recurringScheduleUse.NewFindRecurringScheduleUseCase(recurringScheduleRepository),
 	)
 	group := r.Group("/facilities/:facility_id/schedules")
 	group.POST("", h.CreateSchedule)
@@ -218,6 +220,13 @@ func scheduleRoute(r *gin.RouterGroup) {
 
 	group = r.Group("/facilities/:facility_id/schedules/recurring")
 	group.POST("", h.CreateRecurringSchedule)
+
+	group = r.Group("/schedules/:schedule_id")
+	group.GET("", h.FindScheduleByID)
+
+	group = r.Group("/schedules/recurring/:recurring_schedule_id")
+	group.GET("", h.FindRecurringScheduleByID)
+
 }
 
 func scheduleTypeRoute(r *gin.RouterGroup) {

--- a/internal/usecase/schedule/fetch_schedule_use_case.go
+++ b/internal/usecase/schedule/fetch_schedule_use_case.go
@@ -1,0 +1,257 @@
+package schedule
+
+import (
+	"api-buddy/domain/common"
+	scheduleDomain "api-buddy/domain/schedule"
+	recurringRuleDomain "api-buddy/domain/schedule/recurring_rule"
+	recurringScheduleDomain "api-buddy/domain/schedule/recurring_schedule"
+	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
+	visitInfoDomain "api-buddy/domain/visit_info"
+	visitCategoryDomain "api-buddy/domain/visit_info/visit_category"
+	"context"
+	"log"
+
+	"github.com/Fukuemon/go-pkg/query"
+)
+
+type FetchScheduleUseCase struct {
+	scheduleRepository          scheduleDomain.ScheduleRepository
+	recurringScheduleRepository recurringScheduleDomain.RecurringScheduleRepository
+}
+
+func NewFetchScheduleUseCase(scheduleRepository scheduleDomain.ScheduleRepository, recurringScheduleRepository recurringScheduleDomain.RecurringScheduleRepository) *FetchScheduleUseCase {
+	return &FetchScheduleUseCase{
+		scheduleRepository:          scheduleRepository,
+		recurringScheduleRepository: recurringScheduleRepository,
+	}
+}
+
+// Output DTO
+type FetchScheduleUseCaseOutputDto struct {
+	Schedules          []*ScheduleModel
+	RecurringSchedules []*RecurringScheduleModel
+}
+
+type ScheduleModel struct {
+	ID             string
+	ScheduleType   scheduleTypeDomain.ScheduleTypeEnum
+	Date           common.Date
+	StartTime      common.Time
+	EndTime        common.Time
+	IsOverTimeWork bool
+	StaffName      string
+	VisitInfo      *visitInfoModel
+	Title          string
+	Description    string
+	CancelReason   string
+}
+
+type visitInfoModel struct {
+	Patient         string
+	AssignedStaff   string
+	Companion       string
+	Route           *routeModel
+	ServiceCode     string
+	VisitCategories []visitCategoryModel
+}
+
+type routeModel struct {
+	TravelTime  int
+	Address     string
+	Destination string
+}
+
+type visitCategoryModel struct {
+	ID   string
+	Name visitCategoryDomain.VisitCategoryType
+}
+
+type RecurringScheduleModel struct {
+	ID             string
+	RecurringRule  *RecurringRuleModel
+	ScheduleType   scheduleTypeDomain.ScheduleTypeEnum
+	Date           common.Date
+	StartTime      common.Time
+	EndTime        common.Time
+	IsOverTimeWork bool
+	StaffName      string
+	VisitInfo      *visitInfoModel
+	Title          string
+	Description    string
+	ExclusionDates *common.JSONSlice[int]
+}
+
+type RecurringRuleModel struct {
+	Frequency   recurringRuleDomain.FrequencyEnum
+	DayOfWeek   int
+	DayOfMonth  int
+	WeekOfMonth int
+	StartDate   common.Date
+	EndDate     common.Date
+}
+
+// Input DTO
+type FetchScheduleUseCaseInputDto struct {
+	ScheduleType string
+	SortField    string
+	SortOrder    string
+}
+
+func (uc *FetchScheduleUseCase) Run(ctx context.Context, facilityID string, input FetchScheduleUseCaseInputDto) (*FetchScheduleUseCaseOutputDto, error) {
+	outputDto := FetchScheduleUseCaseOutputDto{}
+	filters := uc.buildFilters(input)
+	sortOption := query.SortOption{
+		Field: input.SortField,
+		Order: input.SortOrder,
+	}
+
+	schedules, err := uc.scheduleRepository.FindByFacilityID(ctx, facilityID, filters, sortOption)
+	if err != nil {
+		return nil, err
+	}
+
+	scheduleList := make([]scheduleDomain.Schedule, len(schedules))
+	for i, schedule := range schedules {
+		scheduleList[i] = *schedule
+	}
+	outputDto.Schedules = uc.buildScheduleModels(scheduleList)
+
+	recurringSchedules, err := uc.recurringScheduleRepository.FindByFacilityID(ctx, facilityID, filters, sortOption)
+	if err != nil {
+		return nil, err
+	}
+	log.Println("recurringSchedules", recurringSchedules)
+	recurringScheduleList := make([]recurringScheduleDomain.RecurringSchedule, len(recurringSchedules))
+	for i, recurringSchedule := range recurringSchedules {
+		recurringScheduleList[i] = *recurringSchedule
+	}
+	outputDto.RecurringSchedules = uc.buildRecurringScheduleModels(recurringScheduleList)
+
+	return &outputDto, nil
+}
+
+func (uc *FetchScheduleUseCase) buildFilters(input FetchScheduleUseCaseInputDto) []query.Filter {
+	var filters []query.Filter
+	if input.ScheduleType != "" {
+		filters = append(filters, &query.ByFieldFilter{
+			Field:           "schedule_type",
+			Value:           input.ScheduleType,
+			RelationMapping: scheduleDomain.ScheduleRelationMappings,
+		})
+	}
+	return filters
+}
+
+func (uc *FetchScheduleUseCase) buildScheduleModels(schedules []scheduleDomain.Schedule) []*ScheduleModel {
+	models := make([]*ScheduleModel, 0, len(schedules))
+	for _, schedule := range schedules {
+		models = append(models, &ScheduleModel{
+			ID:             schedule.ID,
+			ScheduleType:   schedule.ScheduleType.Name,
+			Date:           schedule.Date,
+			StartTime:      schedule.StartTime,
+			EndTime:        schedule.EndTime,
+			IsOverTimeWork: schedule.IsOverTimeWork,
+			StaffName:      schedule.Staff.Username,
+			VisitInfo:      uc.buildVisitInfoModel(schedule.VisitInfo),
+			Title:          schedule.Title,
+			Description:    schedule.Description,
+			CancelReason: func() string {
+				if schedule.ScheduleCancel != nil {
+					return schedule.ScheduleCancel.Reason
+				}
+				return ""
+			}(),
+		})
+	}
+	return models
+}
+
+func (uc *FetchScheduleUseCase) buildRecurringScheduleModels(recurringSchedules []recurringScheduleDomain.RecurringSchedule) []*RecurringScheduleModel {
+	models := make([]*RecurringScheduleModel, 0, len(recurringSchedules))
+	for _, recurringSchedule := range recurringSchedules {
+		models = append(models, &RecurringScheduleModel{
+			ID:             recurringSchedule.ID,
+			ScheduleType:   recurringSchedule.ScheduleType.Name,
+			Date:           recurringSchedule.Date,
+			StartTime:      recurringSchedule.StartTime,
+			EndTime:        recurringSchedule.EndTime,
+			IsOverTimeWork: recurringSchedule.IsOverTimeWork,
+			StaffName:      recurringSchedule.Staff.Username,
+			VisitInfo:      uc.buildVisitInfoModel(recurringSchedule.VisitInfo),
+			Title:          recurringSchedule.Title,
+			Description:    recurringSchedule.Description,
+			ExclusionDates: recurringSchedule.RecurringExclusionDates,
+			RecurringRule: func() *RecurringRuleModel {
+				if recurringSchedule.RecurringRule != nil {
+					return &RecurringRuleModel{
+						Frequency:   recurringSchedule.RecurringRule.Frequency,
+						DayOfWeek:   recurringSchedule.RecurringRule.DayOfWeek,
+						DayOfMonth:  recurringSchedule.RecurringRule.DayOfMonth,
+						WeekOfMonth: recurringSchedule.RecurringRule.WeekOfMonth,
+						StartDate:   recurringSchedule.RecurringRule.StartDate,
+						EndDate:     recurringSchedule.RecurringRule.EndDate,
+					}
+				}
+				return nil
+			}(),
+		})
+	}
+	return models
+}
+
+func (uc *FetchScheduleUseCase) buildVisitInfoModel(visitInfo *visitInfoDomain.VisitInfo) *visitInfoModel {
+	if visitInfo == nil {
+		return nil // visitInfoがnilの場合、nilを返す
+	}
+
+	var route *routeModel
+	if visitInfo.Route != nil {
+		route = &routeModel{
+			TravelTime: visitInfo.Route.TravelTime,
+			Address: func() string {
+				if visitInfo.Route.Address != nil {
+					return visitInfo.Route.Address.JoinAddress()
+				}
+				return ""
+			}(),
+			Destination: func() string {
+				if visitInfo.Route.Destination != nil {
+					return visitInfo.Route.Destination.JoinAddress()
+				}
+				return ""
+			}(),
+		}
+	}
+
+	return &visitInfoModel{
+		Patient:       visitInfo.Patient.Name,
+		AssignedStaff: visitInfo.AssignedStaff.Username,
+		Companion: func() string {
+			if visitInfo.Companion != nil {
+				return visitInfo.Companion.Username
+			}
+			return ""
+		}(),
+		Route: route,
+		ServiceCode: func() string {
+			if visitInfo.ServiceCode != nil {
+				return visitInfo.ServiceCode.Code
+			}
+			return ""
+		}(),
+		VisitCategories: func() []visitCategoryModel {
+			if visitInfo.VisitCategories == nil {
+				return []visitCategoryModel{}
+			}
+			models := make([]visitCategoryModel, 0, len(visitInfo.VisitCategories))
+			for _, visitCategory := range visitInfo.VisitCategories {
+				models = append(models, visitCategoryModel{
+					ID:   visitCategory.ID,
+					Name: visitCategory.Name,
+				})
+			}
+			return models
+		}(),
+	}
+}

--- a/internal/usecase/schedule/fetch_schedules_use_case.go
+++ b/internal/usecase/schedule/fetch_schedules_use_case.go
@@ -9,7 +9,6 @@ import (
 	visitInfoDomain "api-buddy/domain/visit_info"
 	visitCategoryDomain "api-buddy/domain/visit_info/visit_category"
 	"context"
-	"log"
 
 	"github.com/Fukuemon/go-pkg/query"
 )
@@ -40,13 +39,13 @@ type ScheduleModel struct {
 	EndTime        common.Time
 	IsOverTimeWork bool
 	StaffName      string
-	VisitInfo      *visitInfoModel
+	VisitInfo      *VisitInfoModel
 	Title          string
 	Description    string
 	CancelReason   string
 }
 
-type visitInfoModel struct {
+type VisitInfoModel struct {
 	Patient         string
 	AssignedStaff   string
 	Companion       string
@@ -75,7 +74,7 @@ type RecurringScheduleModel struct {
 	EndTime        common.Time
 	IsOverTimeWork bool
 	StaffName      string
-	VisitInfo      *visitInfoModel
+	VisitInfo      *VisitInfoModel
 	Title          string
 	Description    string
 	ExclusionDates *common.JSONSlice[int]
@@ -120,7 +119,6 @@ func (uc *FetchScheduleUseCase) Run(ctx context.Context, facilityID string, inpu
 	if err != nil {
 		return nil, err
 	}
-	log.Println("recurringSchedules", recurringSchedules)
 	recurringScheduleList := make([]recurringScheduleDomain.RecurringSchedule, len(recurringSchedules))
 	for i, recurringSchedule := range recurringSchedules {
 		recurringScheduleList[i] = *recurringSchedule
@@ -200,7 +198,7 @@ func (uc *FetchScheduleUseCase) buildRecurringScheduleModels(recurringSchedules 
 	return models
 }
 
-func (uc *FetchScheduleUseCase) buildVisitInfoModel(visitInfo *visitInfoDomain.VisitInfo) *visitInfoModel {
+func (uc *FetchScheduleUseCase) buildVisitInfoModel(visitInfo *visitInfoDomain.VisitInfo) *VisitInfoModel {
 	if visitInfo == nil {
 		return nil // visitInfoがnilの場合、nilを返す
 	}
@@ -224,7 +222,7 @@ func (uc *FetchScheduleUseCase) buildVisitInfoModel(visitInfo *visitInfoDomain.V
 		}
 	}
 
-	return &visitInfoModel{
+	return &VisitInfoModel{
 		Patient:       visitInfo.Patient.Name,
 		AssignedStaff: visitInfo.AssignedStaff.Username,
 		Companion: func() string {

--- a/internal/usecase/schedule/find_schedule_use_case.go
+++ b/internal/usecase/schedule/find_schedule_use_case.go
@@ -1,0 +1,117 @@
+package schedule
+
+import (
+	"api-buddy/domain/common"
+	scheduleDomain "api-buddy/domain/schedule"
+	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
+	visitInfoDomain "api-buddy/domain/visit_info"
+	"context"
+)
+
+type FindScheduleUseCase struct {
+	scheduleRepository scheduleDomain.ScheduleRepository
+}
+
+func NewFindScheduleUseCase(scheduleRepository scheduleDomain.ScheduleRepository) *FindScheduleUseCase {
+	return &FindScheduleUseCase{
+		scheduleRepository: scheduleRepository,
+	}
+}
+
+type FindScheduleUseCaseOutputDto struct {
+	ID             string
+	ScheduleType   *scheduleTypeDomain.ScheduleTypeEnum
+	Date           common.Date
+	StartTime      common.Time
+	EndTime        common.Time
+	IsOverTimeWork bool
+	StaffName      string
+	VisitInfo      *VisitInfoModel
+	Title          *string
+	Description    *string
+	CancelReason   *string
+}
+
+func (uc *FindScheduleUseCase) Run(ctx context.Context, scheduleID string) (*FindScheduleUseCaseOutputDto, error) {
+	schedule, err := uc.scheduleRepository.FindByID(ctx, scheduleID)
+	if err != nil {
+		return nil, err
+	}
+
+	outputDto := &FindScheduleUseCaseOutputDto{
+		ID:             schedule.ID,
+		ScheduleType:   &schedule.ScheduleType.Name,
+		Date:           schedule.Date,
+		StartTime:      schedule.StartTime,
+		EndTime:        schedule.EndTime,
+		IsOverTimeWork: schedule.IsOverTimeWork,
+		StaffName:      schedule.Staff.Username,
+		VisitInfo:      BuildVisitInfoModel(schedule.VisitInfo),
+		Title:          &schedule.Title,
+		Description:    &schedule.Description,
+		CancelReason: func() *string {
+			if schedule.ScheduleCancel != nil {
+				return &schedule.ScheduleCancel.Reason
+			}
+			return nil
+		}(),
+	}
+
+	return outputDto, nil
+}
+
+func BuildVisitInfoModel(visitInfo *visitInfoDomain.VisitInfo) *VisitInfoModel {
+	if visitInfo == nil {
+		return nil // visitInfoがnilの場合、nilを返す
+	}
+
+	var route *routeModel
+	if visitInfo.Route != nil {
+		route = &routeModel{
+			TravelTime: visitInfo.Route.TravelTime,
+			Address: func() string {
+				if visitInfo.Route.Address != nil {
+					return visitInfo.Route.Address.JoinAddress()
+				}
+				return ""
+			}(),
+			Destination: func() string {
+				if visitInfo.Route.Destination != nil {
+					return visitInfo.Route.Destination.JoinAddress()
+				}
+				return ""
+			}(),
+		}
+	}
+
+	return &VisitInfoModel{
+		Patient:       visitInfo.Patient.Name,
+		AssignedStaff: visitInfo.AssignedStaff.Username,
+		Companion: func() string {
+			if visitInfo.Companion != nil {
+				return visitInfo.Companion.Username
+			}
+			return ""
+		}(),
+		Route: route,
+		ServiceCode: func() string {
+			if visitInfo.ServiceCode != nil {
+				return visitInfo.ServiceCode.Code
+			}
+			return ""
+		}(),
+		VisitCategories: func() []visitCategoryModel {
+			if visitInfo.VisitCategories == nil {
+				return []visitCategoryModel{}
+			}
+			models := make([]visitCategoryModel, 0, len(visitInfo.VisitCategories))
+			for _, visitCategory := range visitInfo.VisitCategories {
+				models = append(models, visitCategoryModel{
+					ID:   visitCategory.ID,
+					Name: visitCategory.Name,
+				})
+			}
+			return models
+		}(),
+	}
+}

--- a/internal/usecase/schedule/recurring_schedule/find_schedule_use_case.go
+++ b/internal/usecase/schedule/recurring_schedule/find_schedule_use_case.go
@@ -1,0 +1,59 @@
+package recurring_schedule
+
+import (
+	"api-buddy/domain/common"
+	recurringRuleDomain "api-buddy/domain/schedule/recurring_rule"
+	recurringScheduleDomain "api-buddy/domain/schedule/recurring_schedule"
+	scheduleTypeDomain "api-buddy/domain/schedule/schedule_type"
+	scheduleUse "api-buddy/usecase/schedule"
+	"context"
+)
+
+type FindRecurringScheduleUseCase struct {
+	recurringScheduleRepository recurringScheduleDomain.RecurringScheduleRepository
+}
+
+func NewFindRecurringScheduleUseCase(recurringScheduleRepository recurringScheduleDomain.RecurringScheduleRepository) *FindRecurringScheduleUseCase {
+	return &FindRecurringScheduleUseCase{
+		recurringScheduleRepository: recurringScheduleRepository,
+	}
+}
+
+type FindRecurringScheduleUseCaseOutputDto struct {
+	ID             string
+	ScheduleType   *scheduleTypeDomain.ScheduleTypeEnum
+	RecurringRule  *recurringRuleDomain.RecurringRule
+	Date           common.Date
+	StartTime      common.Time
+	EndTime        common.Time
+	IsOverTimeWork bool
+	StaffName      string
+	VisitInfo      *scheduleUse.VisitInfoModel
+	Title          *string
+	Description    *string
+	ExclusionDates *common.JSONSlice[int]
+}
+
+func (uc *FindRecurringScheduleUseCase) Run(ctx context.Context, scheduleID string) (*FindRecurringScheduleUseCaseOutputDto, error) {
+	recurringSchedule, err := uc.recurringScheduleRepository.FindByID(ctx, scheduleID)
+	if err != nil {
+		return nil, err
+	}
+
+	outputDto := &FindRecurringScheduleUseCaseOutputDto{
+		ID:             recurringSchedule.ID,
+		ScheduleType:   &recurringSchedule.ScheduleType.Name,
+		RecurringRule:  recurringSchedule.RecurringRule,
+		Date:           recurringSchedule.Date,
+		StartTime:      recurringSchedule.StartTime,
+		EndTime:        recurringSchedule.EndTime,
+		IsOverTimeWork: recurringSchedule.IsOverTimeWork,
+		StaffName:      recurringSchedule.Staff.Username,
+		VisitInfo:      scheduleUse.BuildVisitInfoModel(recurringSchedule.VisitInfo),
+		Title:          &recurringSchedule.Title,
+		Description:    &recurringSchedule.Description,
+		ExclusionDates: recurringSchedule.RecurringExclusionDates,
+	}
+
+	return outputDto, nil
+}


### PR DESCRIPTION
## 関連：issue・Ticket
#34 

## 概要
下記のエンドポイントを追加
- 施設に紐づく全ての予定（繰り返し予定も含む）を返す
- IDに紐づく予定詳細を返す
- IDに紐づく繰り返し予定を返す

## 変更点

-
-

## 今後やること

- [ ]
- [ ]
- [ ]

## 参考

(参考になった文献などがあれば貼り付ける)
